### PR TITLE
Prevent service worker reload loop on mobile

### DIFF
--- a/components/pwa/PWAProvider.tsx
+++ b/components/pwa/PWAProvider.tsx
@@ -32,9 +32,11 @@ export function PWAProvider({ children }: PWAProviderProps) {
     }
 
     const handleControllerChange = () => {
-      console.log('🔄 PWA: Controller changed')
-      // Reload the page to get the new version
-      window.location.reload()
+      console.log('🔄 PWA: Controller changed - new service worker active')
+      // Previously we forced a full reload here which caused mobile browsers to briefly
+      // render the page and then flash to a white screen while the reload occurred.
+      // Let the app continue running – the new service worker will serve updated assets
+      // without interrupting the current session.
     }
 
     const handleOnline = () => {


### PR DESCRIPTION
## Summary
- stop forcing a window reload when the service worker controller changes so that mobile browsers no longer flash white after the first render
- document the reason inside `PWAProvider` so future updates know why the reload was removed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0548f951083239b27b92037425777