### PR TITLE
Fix mobile Safari navigation detection

### DIFF
--- a/components/pwa/MobileNavigation.tsx
+++ b/components/pwa/MobileNavigation.tsx
@@ -14,11 +14,12 @@ export function MobileNavigation({ currentView, onViewChange }: MobileNavigation
   if (!isMobile) return null
 
   const navigationItems = [
-    { id: 'dashboard', label: 'Dashboard', icon: '🏠' },
-    { id: 'money', label: 'Money', icon: '💰' },
+    { id: 'overview', label: 'Overview', icon: '🏠' },
+    { id: 'expenses', label: 'Money', icon: '💰' },
     { id: 'goals', label: 'Goals', icon: '🎯' },
-    { id: 'partnerships', label: 'Partners', icon: '👥' },
-    { id: 'analytics', label: 'Analytics', icon: '📊' }
+    { id: 'partnerships', label: 'Partners', icon: '🤝' },
+    { id: 'analytics', label: 'Analytics', icon: '📊' },
+    { id: 'account', label: 'Account', icon: '👤' }
   ]
 
   return (

--- a/lib/service-worker.ts
+++ b/lib/service-worker.ts
@@ -372,8 +372,19 @@ export const serviceWorkerUtils = {
    */
   isStandalone(): boolean {
     if (typeof window === 'undefined') return false
-    return window.matchMedia('(display-mode: standalone)').matches ||
-           (window.navigator as any).standalone === true
+
+    // Standard display-mode checks
+    const standaloneModes = ['standalone', 'fullscreen', 'minimal-ui']
+    if (standaloneModes.some(mode => window.matchMedia(`(display-mode: ${mode})`).matches)) {
+      return true
+    }
+
+    // iOS specific homescreen detection
+    if ((window.navigator as any).standalone === true) {
+      return true
+    }
+
+    return false
   },
 
   /**
@@ -381,9 +392,16 @@ export const serviceWorkerUtils = {
    */
   isPWA(): boolean {
     if (typeof window === 'undefined') return false
-    return this.isStandalone() || 
-           window.location.protocol === 'https:' && 
-           this.isSupported()
+
+    if (this.isStandalone()) {
+      return true
+    }
+
+    if (typeof document !== 'undefined' && document.referrer?.startsWith('android-app://')) {
+      return true
+    }
+
+    return false
   }
 }
 


### PR DESCRIPTION
## Summary
- update the PWA mobile navigation to use the same view identifiers as the core dashboard so taps show the correct screens
- tighten the PWA detection helper to only report true when running in standalone/app contexts, preventing mobile Safari from misclassifying the browser experience

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3155546088323857870b4c6fd9630