### PR TITLE
Fix Safari runtime bootstrap so UI loads

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -143,7 +143,53 @@ export default function RootLayout({
         <link rel="preconnect" href="https://vercel.live" />
         <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
         <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
-        
+
+        {/* Ensure Next.js runtime script loads correctly on Safari */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  var head = document.head;
+                  if (!head) return;
+
+                  var cssScripts = head.querySelectorAll('script[src$=".css"]');
+                  cssScripts.forEach(function(node) {
+                    if (node.parentNode) {
+                      node.parentNode.removeChild(node);
+                    }
+                  });
+
+                  var preload = head.querySelector('link[rel="preload"][as="script"][href*="/_next/static/chunks/webpack"]');
+                  if (!preload) return;
+
+                  var runtimeSrc = preload.getAttribute('href') || preload.href;
+                  if (!runtimeSrc) return;
+
+                  if (!head.querySelector('script[src="' + runtimeSrc + '"]')) {
+                    var runtimeScript = document.createElement('script');
+                    runtimeScript.src = runtimeSrc;
+                    runtimeScript.async = false;
+                    var crossOrigin = preload.getAttribute('crossorigin');
+                    if (crossOrigin) {
+                      runtimeScript.setAttribute('crossorigin', crossOrigin);
+                    }
+
+                    var firstScript = head.querySelector('script[src^="/_next/static/chunks/"]');
+                    if (firstScript && firstScript.parentNode) {
+                      firstScript.parentNode.insertBefore(runtimeScript, firstScript);
+                    } else {
+                      head.appendChild(runtimeScript);
+                    }
+                  }
+                } catch (error) {
+                  console.error('⚠️ Failed to repair Next.js runtime bootstrap', error);
+                }
+              })();
+            `
+          }}
+        />
+
         {/* PWA Manifest */}
         <link rel="manifest" href="/manifest.json" />
         


### PR DESCRIPTION
## Summary
- add an inline head script that removes erroneous CSS script tags and injects the Next.js runtime chunk for Safari
- ensure the runtime chunk is loaded before other Next.js bundles by inserting it ahead of vendor scripts and preserving crossOrigin attributes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4fe2eb5e88323971355239ff7f1ff