### PR TITLE
Add cross-browser responsive testing report

### DIFF
--- a/QA_SAFARI_FIREFOX_TESTING.md
+++ b/QA_SAFARI_FIREFOX_TESTING.md
@@ -1,0 +1,28 @@
+# Cross-Browser Responsive Smoke Test
+
+## Environment
+- Application: local Next.js dev server (`npm run dev`)
+- Date: 2025-09-26 15:18 UTC
+- Pages reviewed: `/` landing screen
+
+## Test Matrix
+| Browser | Viewport | Result | Notes |
+|---------|----------|--------|-------|
+| Safari (WebKit) | Mobile (390x844) | Pass | Layout renders primary hero, CTA buttons stack correctly, bottom navigation remains accessible. |
+| Safari (WebKit) | Tablet (1024x1366) | Pass | Sidebar content centers, spacing consistent, cards align in grid without overlap. |
+| Safari (WebKit) | Desktop (1280x800) | Pass | Hero and feature grid display with expected spacing, no console errors observed. |
+| Firefox | Mobile (390x844) | Pass | Content stacks vertically, typography legible, no horizontal scrolling. |
+| Firefox | Tablet (1024x1366) | Pass | Grid adapts to two columns, buttons align correctly. |
+| Firefox | Desktop (1280x800) | Pass | Layout uses full width, header/navigation visible and functional. |
+
+## Observations
+- Supabase warnings appear in terminal logs due to mock configuration in development. No blocking issues.
+- Initial loading spinner briefly visible on each navigation as expected for unauthenticated state.
+
+## Artifacts
+- Safari mobile: `browser:/invocations/zhjoslzh/artifacts/artifacts/safari-mobile.png`
+- Safari tablet: `browser:/invocations/zhjoslzh/artifacts/artifacts/safari-tablet.png`
+- Safari desktop: `browser:/invocations/zhjoslzh/artifacts/artifacts/safari-desktop.png`
+- Firefox mobile: `browser:/invocations/zhjoslzh/artifacts/artifacts/firefox-mobile.png`
+- Firefox tablet: `browser:/invocations/zhjoslzh/artifacts/artifacts/firefox-tablet.png`
+- Firefox desktop: `browser:/invocations/zhjoslzh/artifacts/artifacts/firefox-desktop.png`


### PR DESCRIPTION
## Summary
- document results of manual responsive smoke testing across Safari (WebKit) and Firefox for mobile, tablet, and desktop breakpoints
- capture environment details, observations, and links to collected screenshots

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d6ae3ddcbc832384ba9acd386add9e