### PR TITLE
Fix structured data hydration mismatch

### DIFF
--- a/components/ui/StructuredData.tsx
+++ b/components/ui/StructuredData.tsx
@@ -1,30 +1,36 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useCallback, useMemo } from 'react'
 
 interface StructuredDataProps {
-  type: 'website' | 'organization' | 'webapp' | 'article' | 'faq' | 'financialService'
-  data: any
+  type: 'website' | 'organization' | 'webapp' | 'article' | 'faq' | 'financialService' | 'mobileApp'
+  data?: any
 }
 
 export function StructuredData({ type, data }: StructuredDataProps) {
-  useEffect(() => {
-    // Remove existing structured data
-    const existingScripts = document.querySelectorAll('script[type="application/ld+json"]')
-    existingScripts.forEach(script => script.remove())
+  const schema = useMemo(() => {
+    const resolved = data ?? structuredDataSchemas[type]
 
-    // Add new structured data
-    const script = document.createElement('script')
-    script.type = 'application/ld+json'
-    script.text = JSON.stringify(data)
-    document.head.appendChild(script)
-
-    return () => {
-      script.remove()
+    try {
+      return JSON.stringify(resolved)
+    } catch (error) {
+      console.error('Failed to serialize structured data schema', { type, error })
+      return null
     }
-  }, [data])
+  }, [type, data])
 
-  return null
+  if (!schema) {
+    return null
+  }
+
+  return (
+    <script
+      id={`structured-data-${type}`}
+      type="application/ld+json"
+      suppressHydrationWarning
+      dangerouslySetInnerHTML={{ __html: schema }}
+    />
+  )
 }
 
 // Predefined structured data schemas
@@ -224,19 +230,26 @@ export const structuredDataSchemas = {
 
 // Hook for easy structured data usage
 export function useStructuredData() {
-  const addStructuredData = (type: keyof typeof structuredDataSchemas, customData?: any) => {
-    const schema = customData || structuredDataSchemas[type]
-    
-    // Remove existing structured data
-    const existingScripts = document.querySelectorAll('script[type="application/ld+json"]')
-    existingScripts.forEach(script => script.remove())
+  const addStructuredData = useCallback((type: keyof typeof structuredDataSchemas, customData?: any) => {
+    if (typeof document === 'undefined') {
+      return
+    }
 
-    // Add new structured data
-    const script = document.createElement('script')
-    script.type = 'application/ld+json'
-    script.text = JSON.stringify(schema)
-    document.head.appendChild(script)
-  }
+    const schema = customData ?? structuredDataSchemas[type]
+    const scriptId = `structured-data-${type}`
+    const serialized = JSON.stringify(schema)
+
+    let script = document.head.querySelector<HTMLScriptElement>(`#${scriptId}`)
+
+    if (!script) {
+      script = document.createElement('script')
+      script.id = scriptId
+      script.type = 'application/ld+json'
+      document.head.appendChild(script)
+    }
+
+    script.text = serialized
+  }, [])
 
   return { addStructuredData }
 }


### PR DESCRIPTION
## Summary
- render JSON-LD structured data tags declaratively to avoid hydration mismatches
- update the structured data hook to target script elements without removing unrelated tags

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6b07caef0832384d63ac45e1a5e99