### PR TITLE
Fix PWA service worker React import

### DIFF
--- a/lib/service-worker.ts
+++ b/lib/service-worker.ts
@@ -1,3 +1,5 @@
+import React from 'react'
+
 /**
  * Service Worker Registration and Management
  * Handles registration, updates, and communication with the service worker


### PR DESCRIPTION
## Summary
- import React in the service worker manager module so the hook utilities can access the React namespace at runtime, preventing client-side crashes when the PWA provider loads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7a26a85a48323b1978eb6b5b10b83