### PR TITLE
Avoid caching the root document in the service worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -8,8 +8,10 @@ const STATIC_CACHE = 'splitsave-static-v1.0.0'
 const DYNAMIC_CACHE = 'splitsave-dynamic-v1.0.0'
 
 // Assets to cache immediately
+// Only precache truly static assets. Avoid caching the root document because
+// Next.js streams the shell HTML and caching it can capture an empty loading
+// state that never hydrates when returned offline or from a stale cache.
 const STATIC_ASSETS = [
-  '/',
   '/manifest.json',
   '/icon-192x192.png',
   '/icon-512x512.png',


### PR DESCRIPTION
## Summary
- stop precaching the `/` document in the PWA service worker to avoid serving a blank cached shell on mobile
- add documentation in the worker about only caching immutable assets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7a2e6654c8323ac1a5ba4fc50b1c3