### PR TITLE
Fix PWA build failure caused by duplicate React import

### DIFF
--- a/lib/service-worker.ts
+++ b/lib/service-worker.ts
@@ -407,5 +407,3 @@ export const serviceWorkerUtils = {
   }
 }
 
-// Import React for the hook
-import React from 'react'


### PR DESCRIPTION
## Summary
- remove the duplicate React import at the bottom of `lib/service-worker.ts` that caused Next.js to fail compiling the PWA entry point

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7b7b46fc48323b594977c653f9037