### PR TITLE
Fix notification dropdown API response parsing

### DIFF
--- a/components/notifications/NotificationDropdown.tsx
+++ b/components/notifications/NotificationDropdown.tsx
@@ -34,11 +34,14 @@ export function NotificationDropdown({ userId, className = '' }: NotificationDro
     setIsLoading(true)
     try {
       const response = await apiClient.get('/notifications')
-      const data = response?.data || response || []
-      const notificationList = Array.isArray(data) ? data : []
-      
+      const data = response?.data ?? {}
+      const notificationList = Array.isArray(data?.notifications) ? data.notifications : []
+      const unreadFromApi = typeof data?.unreadCount === 'number' ? data.unreadCount : null
+
       setNotifications(notificationList)
-      setUnreadCount(notificationList.filter(n => !n.isRead).length)
+      setUnreadCount(
+        unreadFromApi ?? notificationList.filter((notification) => !notification.isRead).length
+      )
     } catch (error) {
       console.error('Failed to fetch notifications:', error)
       // Create some mock notifications for demo purposes
@@ -71,9 +74,9 @@ export function NotificationDropdown({ userId, className = '' }: NotificationDro
           actionUrl: '/' // Redirect to main app where partnerships view is available
         }
       ]
-      
+
       setNotifications(mockNotifications)
-      setUnreadCount(mockNotifications.filter(n => !n.isRead).length)
+      setUnreadCount(mockNotifications.filter((notification) => !notification.isRead).length)
     } finally {
       setIsLoading(false)
     }


### PR DESCRIPTION
## Summary
- parse notifications from the structured API payload instead of casting the entire response
- default to mock notifications if the API request fails while keeping unread counts consistent

## Testing
- Not Run (manual verification required for unread badges is not possible in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d7d14864588323881a59ff37a0a22d