### PR TITLE
Remove references to missing legacy icon assets

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -149,16 +149,8 @@ export default function RootLayout({
         {/* PWA Manifest */}
         <link rel="manifest" href="/manifest.json" />
         
-        {/* Apple Touch Icons */}
+        {/* Apple Touch Icon */}
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-        <link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png" />
-        <link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png" />
-        <link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120.png" />
-        <link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png" />
-        <link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76.png" />
-        <link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png" />
-        <link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png" />
-        <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png" />
         
         {/* Favicons */}
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
@@ -168,8 +160,6 @@ export default function RootLayout({
         
         {/* Microsoft Tiles */}
         <meta name="msapplication-TileColor" content="#7c3aed" />
-        <meta name="msapplication-config" content="/browserconfig.xml" />
-        <meta name="msapplication-TileImage" content="/mstile-144x144.png" />
         
         {/* Theme Color */}
         <meta name="theme-color" content="#7c3aed" media="(prefers-color-scheme: light)" />


### PR DESCRIPTION
## Summary
- remove apple touch icon link tags that pointed to non-existent files
- drop Microsoft tile metadata that referenced missing assets while keeping the tile color

## Testing
- npm run lint *(fails: exiting early due to extensive existing warnings in unrelated files)*
- npm run test:performance *(fails: lighthouse requires a Chrome executable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d14985548323b016c1b80eeddcb8