### PR TITLE
Clear PWA caches after signing out

### DIFF
--- a/components/SplitsaveApp.tsx
+++ b/components/SplitsaveApp.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import { apiClient } from '@/lib/api-client'
 import { toast } from '@/lib/toast'
 import { supabase } from '@/lib/supabase'
+import { serviceWorkerManager } from '@/lib/service-worker'
 
 // Import components
 import { OverviewHub } from './dashboard/OverviewHub'
@@ -180,7 +181,13 @@ export function SplitsaveApp() {
     } catch (error) {
       console.error('Sign out error:', error)
     }
-    
+
+    try {
+      await serviceWorkerManager.clearCaches()
+    } catch (error) {
+      console.error('Failed to clear caches after sign out:', error)
+    }
+
     // Clear local state
     setUser(null)
     setExpenses([])


### PR DESCRIPTION
## Summary
- import the service worker manager into the Splitsave app component
- clear client-side caches after the Supabase sign-out completes to prevent stale data on next login

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7d14a89988323a3f6bf3dbdc112a4