### PR TITLE
Refactor PWA mobile experience and add tests

### DIFF
--- a/__tests__/pwa/MobilePWA.test.tsx
+++ b/__tests__/pwa/MobilePWA.test.tsx
@@ -1,0 +1,165 @@
+import React from 'react'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { MobilePWA, useMobilePWA, isLikelyMobileDevice, BeforeInstallPromptEvent } from '@/components/pwa/MobilePWA'
+
+const mockIsStandalone = jest.fn(() => false)
+const mockIsPWA = jest.fn(() => false)
+
+jest.mock('@/lib/service-worker', () => ({
+  serviceWorkerUtils: {
+    isStandalone: () => mockIsStandalone(),
+    isPWA: () => mockIsPWA()
+  }
+}))
+
+describe('MobilePWA provider', () => {
+  let localStore: Map<string, string>
+  let sessionStore: Map<string, string>
+
+  beforeEach(() => {
+    mockIsStandalone.mockReturnValue(false)
+    mockIsPWA.mockReturnValue(false)
+
+    localStore = new Map<string, string>()
+    sessionStore = new Map<string, string>()
+
+    const createStorage = (store: Map<string, string>) => ({
+      getItem: jest.fn((key: string) => (store.has(key) ? store.get(key) ?? null : null)),
+      setItem: jest.fn((key: string, value: string) => {
+        store.set(key, value)
+      }),
+      removeItem: jest.fn((key: string) => {
+        store.delete(key)
+      }),
+      clear: jest.fn(() => {
+        store.clear()
+      })
+    })
+
+    Object.defineProperty(window, 'localStorage', {
+      value: createStorage(localStore),
+      configurable: true,
+      writable: true
+    })
+
+    Object.defineProperty(window, 'sessionStorage', {
+      value: createStorage(sessionStore),
+      configurable: true,
+      writable: true
+    })
+
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)',
+      configurable: true
+    })
+    Object.defineProperty(window.navigator, 'maxTouchPoints', {
+      value: 5,
+      configurable: true
+    })
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: true,
+      configurable: true
+    })
+    Object.defineProperty(window, 'innerWidth', {
+      value: 375,
+      configurable: true
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('detects likely mobile devices from user agent', () => {
+    expect(isLikelyMobileDevice('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)')).toBe(true)
+    expect(isLikelyMobileDevice('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)', { maxTouchPoints: 4 })).toBe(true)
+    expect(isLikelyMobileDevice('Mozilla/5.0 (Windows NT 10.0; Win64; x64)', { screenWidth: 500 })).toBe(true)
+    expect(isLikelyMobileDevice('Mozilla/5.0 (Windows NT 10.0; Win64; x64)', { screenWidth: 1440 })).toBe(false)
+  })
+
+  it('provides mobile detection and responds to install prompt events', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <MobilePWA>{children}</MobilePWA>
+    )
+
+    const { result } = renderHook(() => useMobilePWA(), { wrapper })
+
+    await waitFor(() => expect(result.current.isClient).toBe(true))
+    expect(result.current.isMobile).toBe(true)
+    expect(result.current.canInstall).toBe(false)
+
+    await act(async () => {
+      const event = new Event('beforeinstallprompt') as BeforeInstallPromptEvent & {
+        prompt: jest.Mock
+      }
+      event.prompt = jest.fn().mockResolvedValue(undefined)
+      event.userChoice = Promise.resolve({ outcome: 'accepted', platform: 'web' })
+      ;(event as any).platforms = ['web']
+      window.dispatchEvent(event)
+    })
+
+    await waitFor(() => expect(result.current.canInstall).toBe(true))
+    expect(result.current.showInstallPrompt).toBe(true)
+
+    await act(async () => {
+      await result.current.requestInstall()
+    })
+
+    await waitFor(() => expect(result.current.showInstallPrompt).toBe(false))
+    expect(localStore.get('pwa-install-dismissed')).toBe('true')
+    expect(sessionStore.get('pwa-install-dismissed')).toBe('true')
+  })
+
+  it('updates online state in response to browser events', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <MobilePWA>{children}</MobilePWA>
+    )
+
+    const { result } = renderHook(() => useMobilePWA(), { wrapper })
+
+    await waitFor(() => expect(result.current.isClient).toBe(true))
+    expect(result.current.isOnline).toBe(true)
+
+    act(() => {
+      window.dispatchEvent(new Event('offline'))
+    })
+
+    await waitFor(() => expect(result.current.isOnline).toBe(false))
+
+    act(() => {
+      window.dispatchEvent(new Event('online'))
+    })
+
+    await waitFor(() => expect(result.current.isOnline).toBe(true))
+  })
+
+  it('allows users to dismiss the install prompt permanently', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <MobilePWA>{children}</MobilePWA>
+    )
+
+    const { result } = renderHook(() => useMobilePWA(), { wrapper })
+
+    await waitFor(() => expect(result.current.isClient).toBe(true))
+
+    act(() => {
+      const event = new Event('beforeinstallprompt') as BeforeInstallPromptEvent & {
+        prompt: jest.Mock
+      }
+      event.prompt = jest.fn().mockResolvedValue(undefined)
+      event.userChoice = Promise.resolve({ outcome: 'dismissed', platform: 'web' })
+      ;(event as any).platforms = ['web']
+      window.dispatchEvent(event)
+    })
+
+    await waitFor(() => expect(result.current.canInstall).toBe(true))
+
+    act(() => {
+      result.current.dismissInstallPrompt({ persist: true })
+    })
+
+    expect(localStore.get('pwa-install-dismissed')).toBe('true')
+    expect(result.current.showInstallPrompt).toBe(false)
+  })
+})
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -433,3 +433,19 @@
   }
 }
 
+/* PWA + mobile shell helpers */
+html.is-mobile-device,
+html.is-mobile-device body {
+  min-height: 100%;
+  background-color: var(--color-background);
+}
+
+html.is-pwa-experience body {
+  overscroll-behavior-y: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+html.is-standalone-pwa body {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from '@/components/ui/ThemeProvider'
 import { PWAProvider } from '@/components/pwa/PWAProvider'
 import { SafariRuntimeRepair } from '@/components/pwa/SafariRuntimeRepair'
 import { MobilePWA } from '@/components/pwa/MobilePWA'
+import { PWAInstallPrompt, PWAStatus } from '@/components/pwa/PWAInstallPrompt'
 // Debug components removed to prevent hydration issues
 // import { MobileDebugOverlay } from '@/components/mobile/MobileDebugOverlay'
 // import { PWAAuthDebug } from '@/components/debug/PWAAuthDebug'
@@ -308,6 +309,8 @@ export default function RootLayout({
               <SafariRuntimeRepair />
               <MobilePWA>
                 {children}
+                <PWAStatus />
+                <PWAInstallPrompt />
               </MobilePWA>
               <Analytics />
               <SpeedInsights />

--- a/components/pwa/MobilePWA.tsx
+++ b/components/pwa/MobilePWA.tsx
@@ -1,315 +1,378 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import { serviceWorkerUtils } from '@/lib/service-worker'
-import { PWAInstallPrompt, PWAStatus } from './PWAInstallPrompt'
 
-interface MobilePWAProps {
-  children: React.ReactNode
+const INSTALL_DISMISS_KEY = 'pwa-install-dismissed'
+
+export interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[]
+  readonly userChoice: Promise<{
+    outcome: 'accepted' | 'dismissed'
+    platform: string
+  }>
+  prompt(): Promise<void>
 }
 
-export function MobilePWA({ children }: MobilePWAProps) {
-  const [isMobile, setIsMobile] = useState(false)
-  const [isPWA, setIsPWA] = useState(false)
-  const [isStandalone, setIsStandalone] = useState(false)
-  const [showMobileOptimizations, setShowMobileOptimizations] = useState(false)
-  const [isClient, setIsClient] = useState(false)
+export interface MobilePWAContextValue {
+  isClient: boolean
+  isMobile: boolean
+  isStandalone: boolean
+  isPWA: boolean
+  isOnline: boolean
+  canInstall: boolean
+  showInstallPrompt: boolean
+  requestInstall: () => Promise<boolean>
+  dismissInstallPrompt: (options?: { persist?: boolean }) => void
+  resetInstallPrompt: () => void
+}
+
+const MobilePWAContext = createContext<MobilePWAContextValue | null>(null)
+
+const MOBILE_UA_REGEX = /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i
+
+export function isLikelyMobileDevice(
+  userAgent: string,
+  options: { maxTouchPoints?: number; screenWidth?: number } = {}
+): boolean {
+  const normalizedUA = userAgent.toLowerCase()
+
+  if (MOBILE_UA_REGEX.test(normalizedUA)) {
+    return true
+  }
+
+  const { maxTouchPoints, screenWidth } = options
+
+  // Detect iPadOS which reports itself as Mac but has touch support
+  if (normalizedUA.includes('macintosh') && typeof maxTouchPoints === 'number' && maxTouchPoints > 1) {
+    return true
+  }
+
+  if (typeof screenWidth === 'number') {
+    return screenWidth <= 768
+  }
+
+  return false
+}
+
+function getStoredDismissal(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    return (
+      window.localStorage.getItem(INSTALL_DISMISS_KEY) === 'true' ||
+      window.sessionStorage.getItem(INSTALL_DISMISS_KEY) === 'true'
+    )
+  } catch (error) {
+    console.warn('Unable to read install dismissal flag', error)
+    return false
+  }
+}
+
+function persistDismissal(persist: boolean) {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.setItem(INSTALL_DISMISS_KEY, 'true')
+    if (persist) {
+      window.localStorage.setItem(INSTALL_DISMISS_KEY, 'true')
+    }
+  } catch (error) {
+    console.warn('Unable to persist install dismissal flag', error)
+  }
+}
+
+function clearDismissal() {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.removeItem(INSTALL_DISMISS_KEY)
+    window.localStorage.removeItem(INSTALL_DISMISS_KEY)
+  } catch (error) {
+    console.warn('Unable to clear install dismissal flag', error)
+  }
+}
+
+function ensureViewportMetaTag() {
+  if (typeof document === 'undefined') return
+  let viewport = document.querySelector('meta[name="viewport"]')
+  if (!viewport) {
+    viewport = document.createElement('meta')
+    viewport.setAttribute('name', 'viewport')
+    document.head.appendChild(viewport)
+  }
+  viewport.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover')
+}
+
+function ensureMetaTag(name: string, content: string) {
+  if (typeof document === 'undefined') return
+  let meta = document.querySelector(`meta[name="${name}"]`)
+  if (!meta) {
+    meta = document.createElement('meta')
+    meta.setAttribute('name', name)
+    document.head.appendChild(meta)
+  }
+  meta.setAttribute('content', content)
+}
+
+function applyMobileMetaTags() {
+  ensureViewportMetaTag()
+
+  const tags = [
+    ['mobile-web-app-capable', 'yes'],
+    ['apple-mobile-web-app-capable', 'yes'],
+    ['apple-mobile-web-app-status-bar-style', 'default'],
+    ['apple-mobile-web-app-title', 'SplitSave'],
+    ['format-detection', 'telephone=no'],
+    ['theme-color', '#7c3aed']
+  ] as const
+
+  for (const [name, content] of tags) {
+    ensureMetaTag(name, content)
+  }
+}
+
+function updateDocumentClasses(state: {
+  isMobile: boolean
+  isPWA: boolean
+  isStandalone: boolean
+}) {
+  if (typeof document === 'undefined') return
+
+  const { isMobile, isPWA, isStandalone } = state
+  const root = document.documentElement
+  const body = document.body
+
+  const classMap: Array<[string, boolean]> = [
+    ['is-mobile-device', isMobile],
+    ['is-pwa-experience', isPWA],
+    ['is-standalone-pwa', isStandalone]
+  ]
+
+  classMap.forEach(([className, shouldEnable]) => {
+    root.classList.toggle(className, shouldEnable)
+    body.classList.toggle(className, shouldEnable)
+  })
+}
+
+function detectMobileFromEnvironment(): boolean {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+    return false
+  }
+
+  return isLikelyMobileDevice(navigator.userAgent || '', {
+    maxTouchPoints: (navigator as Navigator & { maxTouchPoints?: number }).maxTouchPoints,
+    screenWidth: window.innerWidth
+  })
+}
+
+const initialContextState: MobilePWAContextValue = {
+  isClient: false,
+  isMobile: false,
+  isStandalone: false,
+  isPWA: false,
+  isOnline: true,
+  canInstall: false,
+  showInstallPrompt: false,
+  requestInstall: async () => false,
+  dismissInstallPrompt: () => {},
+  resetInstallPrompt: () => {}
+}
+
+export function MobilePWA({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState(initialContextState)
+  const installPromptRef = useRef<BeforeInstallPromptEvent | null>(null)
+
+  const requestInstall = useCallback(async () => {
+    const promptEvent = installPromptRef.current
+    if (!promptEvent) {
+      return false
+    }
+
+    try {
+      await promptEvent.prompt()
+      const choice = await promptEvent.userChoice
+      const accepted = choice?.outcome === 'accepted'
+
+      setState(prev => ({
+        ...prev,
+        canInstall: accepted ? false : prev.canInstall,
+        showInstallPrompt: false
+      }))
+
+      persistDismissal(accepted)
+      installPromptRef.current = null
+      return accepted
+    } catch (error) {
+      console.error('PWA install prompt failed', error)
+      setState(prev => ({
+        ...prev,
+        showInstallPrompt: false
+      }))
+      installPromptRef.current = null
+      return false
+    }
+  }, [])
+
+  const dismissInstallPrompt = useCallback((options: { persist?: boolean } = {}) => {
+    const shouldPersist = options.persist ?? false
+    persistDismissal(shouldPersist)
+    setState(prev => ({
+      ...prev,
+      showInstallPrompt: false,
+      canInstall: shouldPersist ? false : prev.canInstall
+    }))
+  }, [])
+
+  const resetInstallPrompt = useCallback(() => {
+    clearDismissal()
+    setState(prev => ({
+      ...prev,
+      canInstall: !!installPromptRef.current,
+      showInstallPrompt: !!installPromptRef.current && prev.isMobile
+    }))
+  }, [])
 
   useEffect(() => {
-    // Only run on client side
     if (typeof window === 'undefined') {
       return
     }
 
-    setIsClient(true)
+    let mounted = true
 
-    const checkMobile = () => {
-      const userAgent = navigator.userAgent.toLowerCase()
-      const isMobileDevice = /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(userAgent)
-      setIsMobile(isMobileDevice)
+    const evaluateEnvironment = () => {
+      if (!mounted) return
+      const isStandalone = serviceWorkerUtils.isStandalone()
+      const isPWA = serviceWorkerUtils.isPWA()
+      const isMobile = detectMobileFromEnvironment()
 
-      const shouldEnableOptimizations = isMobileDevice && (serviceWorkerUtils.isPWA() || serviceWorkerUtils.isStandalone())
-      setShowMobileOptimizations(shouldEnableOptimizations)
-    }
+      setState(prev => ({
+        ...prev,
+        isClient: true,
+        isStandalone,
+        isPWA,
+        isMobile,
+        isOnline: navigator.onLine
+      }))
 
-    const checkPWA = () => {
-      const pwa = serviceWorkerUtils.isPWA()
-      const standalone = serviceWorkerUtils.isStandalone()
-      setIsPWA(pwa)
-      setIsStandalone(standalone)
-    }
-
-    checkMobile()
-    checkPWA()
-  }, []) // Remove dependencies to prevent infinite re-renders
-
-  // Add mobile-specific meta tags and viewport settings
-  useEffect(() => {
-    if (isMobile && typeof window !== 'undefined' && typeof document !== 'undefined') {
-      // Set viewport meta tag for mobile
-      let viewport = document.querySelector('meta[name="viewport"]')
-      if (!viewport) {
-        viewport = document.createElement('meta')
-        viewport.setAttribute('name', 'viewport')
-        document.head.appendChild(viewport)
+      updateDocumentClasses({ isMobile, isPWA, isStandalone })
+      if (isMobile) {
+        applyMobileMetaTags()
       }
-      viewport.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover')
+    }
 
-      // Add mobile-specific meta tags
-      const mobileMetaTags = [
-        { name: 'mobile-web-app-capable', content: 'yes' },
-        { name: 'apple-mobile-web-app-capable', content: 'yes' },
-        { name: 'apple-mobile-web-app-status-bar-style', content: 'default' },
-        { name: 'apple-mobile-web-app-title', content: 'SplitSave' },
-        { name: 'format-detection', content: 'telephone=no' },
-        { name: 'theme-color', content: '#7c3aed' }
-      ]
+    evaluateEnvironment()
 
-      mobileMetaTags.forEach(tag => {
-        let meta = document.querySelector(`meta[name="${tag.name}"]`)
-        if (!meta) {
-          meta = document.createElement('meta')
-          meta.setAttribute('name', tag.name)
-          document.head.appendChild(meta)
+    const handleResize = () => {
+      const detectedMobile = detectMobileFromEnvironment()
+      setState(prev => {
+        const nextState = {
+          ...prev,
+          isMobile: detectedMobile
         }
-        meta.setAttribute('content', tag.content)
-      })
-
-      // Add iOS-specific meta tags
-      const iosMetaTags = [
-        { name: 'apple-touch-fullscreen', content: 'yes' },
-        { name: 'apple-mobile-web-app-orientations', content: 'portrait' }
-      ]
-
-      iosMetaTags.forEach(tag => {
-        let meta = document.querySelector(`meta[name="${tag.name}"]`)
-        if (!meta) {
-          meta = document.createElement('meta')
-          meta.setAttribute('name', tag.name)
-          document.head.appendChild(meta)
-        }
-        meta.setAttribute('content', tag.content)
+        updateDocumentClasses({
+          isMobile: detectedMobile,
+          isPWA: nextState.isPWA,
+          isStandalone: nextState.isStandalone
+        })
+        return nextState
       })
     }
-  }, [isMobile])
 
-  // Add mobile-specific CSS classes
-  useEffect(() => {
-    if (isMobile && typeof document !== 'undefined') {
-      document.documentElement.classList.add('mobile-device')
+    const displayModeMedia = typeof window.matchMedia === 'function'
+      ? window.matchMedia('(display-mode: standalone)')
+      : null
 
-      if (isStandalone) {
-        document.documentElement.classList.add('pwa-standalone')
-      }
-
-      if (isPWA) {
-        document.documentElement.classList.add('pwa-mode')
+    const handleDisplayModeChange = () => evaluateEnvironment()
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        evaluateEnvironment()
       }
     }
-  }, [isMobile, isStandalone, isPWA])
 
-  useEffect(() => {
-    if (!isClient) return
+    const handleBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault()
+      const promptEvent = event as BeforeInstallPromptEvent
+      installPromptRef.current = promptEvent
 
-    if (isMobile) {
-      setShowMobileOptimizations(isPWA || isStandalone)
-    } else {
-      setShowMobileOptimizations(false)
+      setState(prev => ({
+        ...prev,
+        canInstall: true,
+        showInstallPrompt: !getStoredDismissal() && prev.isMobile
+      }))
     }
-  }, [isClient, isMobile, isPWA, isStandalone])
 
-  console.log('🔍 MobilePWA render:', { isMobile, isPWA, isStandalone, showMobileOptimizations, isClient })
+    const handleAppInstalled = () => {
+      installPromptRef.current = null
+      persistDismissal(true)
+      evaluateEnvironment()
+      setState(prev => ({
+        ...prev,
+        canInstall: false,
+        showInstallPrompt: false,
+        isStandalone: true,
+        isPWA: true
+      }))
+    }
+
+    const handleOnline = () => {
+      setState(prev => ({
+        ...prev,
+        isOnline: true
+      }))
+    }
+
+    const handleOffline = () => {
+      setState(prev => ({
+        ...prev,
+        isOnline: false
+      }))
+    }
+
+    window.addEventListener('resize', handleResize)
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
+    window.addEventListener('appinstalled', handleAppInstalled)
+    window.addEventListener('online', handleOnline)
+    window.addEventListener('offline', handleOffline)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    displayModeMedia?.addEventListener?.('change', handleDisplayModeChange)
+
+    return () => {
+      mounted = false
+      window.removeEventListener('resize', handleResize)
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
+      window.removeEventListener('appinstalled', handleAppInstalled)
+      window.removeEventListener('online', handleOnline)
+      window.removeEventListener('offline', handleOffline)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      displayModeMedia?.removeEventListener?.('change', handleDisplayModeChange)
+    }
+  }, [])
+
+  const contextValue = useMemo<MobilePWAContextValue>(() => ({
+    ...state,
+    requestInstall,
+    dismissInstallPrompt,
+    resetInstallPrompt
+  }), [dismissInstallPrompt, requestInstall, resetInstallPrompt, state])
 
   return (
-    <>
+    <MobilePWAContext.Provider value={contextValue}>
       {children}
-      
-      {/* PWA Status Indicator */}
-      {/* Only render PWA components on client side */}
-      {isClient && (
-        <>
-          <PWAStatus />
-          
-          {/* PWA Install Prompt */}
-          <PWAInstallPrompt />
-        </>
-      )}
-      
-      {/* Mobile-specific optimizations - ONLY for actual PWA or standalone mode */}
-      {showMobileOptimizations && (isPWA || isStandalone) && (
-        <MobileOptimizations 
-          isPWA={isPWA} 
-          isStandalone={isStandalone} 
-          isMobile={isMobile} 
-        />
-      )}
-    </>
+    </MobilePWAContext.Provider>
   )
 }
 
-interface MobileOptimizationsProps {
-  isPWA: boolean
-  isStandalone: boolean
-  isMobile: boolean
-}
-
-function MobileOptimizations({ isPWA, isStandalone, isMobile }: MobileOptimizationsProps) {
-  useEffect(() => {
-    // Add mobile-specific event listeners (disabled to allow scrolling)
-    const handleTouchStart = (e: TouchEvent) => {
-      // Only prevent zoom on multi-touch, allow single touch scrolling
-      if (e.touches.length > 1) {
-        e.preventDefault()
-      }
-    }
-
-    // Remove touchmove handler that was preventing scrolling
-    // Allow natural scrolling behavior
-
-    // Add passive event listeners for better performance
-    document.addEventListener('touchstart', handleTouchStart, { passive: true })
-
-    return () => {
-      document.removeEventListener('touchstart', handleTouchStart)
-    }
-  }, [])
-
-  // Add mobile-specific styles - SIMPLIFIED to prevent conflicts
-  useEffect(() => {
-    if (typeof document !== 'undefined') {
-      // SIMPLIFIED CSS injection - only essential fixes
-      const immediateStyle = document.createElement('style')
-      immediateStyle.id = 'mobile-immediate-fix'
-      immediateStyle.textContent = `
-        /* ESSENTIAL MOBILE FIX - Prevent white screen with proper dark mode support */
-        html, body {
-          margin: 0 !important;
-          padding: 0 !important;
-          overflow-x: hidden !important;
-          overflow-y: auto !important;
-          -webkit-overflow-scrolling: touch !important;
-        }
-        
-        /* Mobile fixes that respect theme */
-        @media screen and (max-width: 768px) {
-          html, body {
-            min-height: 100vh !important;
-            min-height: 100dvh !important; /* Dynamic viewport height */
-          }
-          
-          /* Only set background if no theme class exists */
-          html:not(.dark), html:not(.dark) body {
-            background: #f9fafb !important;
-            background-color: #f9fafb !important;
-          }
-          
-          /* Dark mode support */
-          html.dark, html.dark body {
-            background: #0f172a !important;
-            background-color: #0f172a !important;
-          }
-        }
-      `
-      document.head.appendChild(immediateStyle)
-
-      // Main mobile styles - SIMPLIFIED to prevent conflicts
-      const style = document.createElement('style')
-      style.id = 'mobile-main-styles'
-      style.textContent = `
-        /* Mobile-specific styles - MINIMAL VERSION */
-        .mobile-device {
-          -webkit-touch-callout: none;
-          -webkit-user-select: none;
-          -khtml-user-select: none;
-          -moz-user-select: none;
-          -ms-user-select: none;
-          user-select: none;
-          /* Enable scrolling */
-          overflow: auto !important;
-          -webkit-overflow-scrolling: touch !important;
-        }
-        
-        .mobile-device input,
-        .mobile-device textarea {
-          -webkit-user-select: text;
-          -khtml-user-select: text;
-          -moz-user-select: text;
-          -ms-user-select: text;
-          user-select: text;
-        }
-        
-        /* PWA standalone mode styles */
-        .pwa-standalone {
-          padding-top: env(safe-area-inset-top);
-          padding-bottom: env(safe-area-inset-bottom);
-          padding-left: env(safe-area-inset-left);
-          padding-right: env(safe-area-inset-right);
-        }
-        
-        /* Mobile viewport fixes - ONLY essential ones */
-        @media screen and (max-width: 768px) {
-          .mobile-device {
-            -webkit-text-size-adjust: 100%;
-            -ms-text-size-adjust: 100%;
-          }
-        }
-        
-        /* iOS specific fixes */
-        @supports (-webkit-touch-callout: none) {
-          .mobile-device {
-            -webkit-overflow-scrolling: touch;
-          }
-        }
-      `
-      document.head.appendChild(style)
-
-      return () => {
-        const immediateStyleEl = document.getElementById('mobile-immediate-fix')
-        const mainStyleEl = document.getElementById('mobile-main-styles')
-        if (immediateStyleEl) document.head.removeChild(immediateStyleEl)
-        if (mainStyleEl) document.head.removeChild(mainStyleEl)
-      }
-    }
-  }, [])
-
-  return null
-}
-
-// Hook to detect mobile and PWA status
-export function useMobilePWA() {
-  const [isMobile, setIsMobile] = useState(false)
-  const [isPWA, setIsPWA] = useState(false)
-  const [isStandalone, setIsStandalone] = useState(false)
-  const [isClient, setIsClient] = useState(false)
-
-  useEffect(() => {
-    // Only run on client side
-    if (typeof window === 'undefined') {
-      return
-    }
-
-    setIsClient(true)
-
-    const checkMobile = () => {
-      const userAgent = navigator.userAgent.toLowerCase()
-      const isMobileDevice = /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(userAgent)
-      setIsMobile(isMobileDevice)
-    }
-
-    const checkPWA = () => {
-      setIsPWA(serviceWorkerUtils.isPWA())
-      setIsStandalone(serviceWorkerUtils.isStandalone())
-    }
-
-    checkMobile()
-    checkPWA()
-  }, [])
-
-  return {
-    isMobile,
-    isPWA,
-    isStandalone,
-    isMobilePWA: isMobile && isPWA,
-    isClient
+export function useMobilePWA(): MobilePWAContextValue {
+  const context = useContext(MobilePWAContext)
+  if (!context) {
+    throw new Error('useMobilePWA must be used within a MobilePWA provider')
   }
+  return context
 }
+


### PR DESCRIPTION
## Summary
- rebuild the MobilePWA provider to centralize detection, install prompt state, and update document classes/metadata for the shell
- simplify the install prompt + status components and render them directly from the app layout with new PWA-specific styles
- add comprehensive tests that cover mobile detection, install prompt handling, and online/offline reactions

## Testing
- npm test -- MobilePWA

------
https://chatgpt.com/codex/tasks/task_e_68d7dfd23e088323b7029da09fc0ad14