### PR TITLE
Fix hydration mismatch when bypassing auth loading

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -148,7 +148,7 @@ export default function Home() {
   )
 
   if (loading) {
-    const shouldBypassLoading = hasAuthToken === false
+    const shouldBypassLoading = isClient && hasAuthToken === false
 
     if (shouldBypassLoading) {
       console.log('🚀 No stored session detected - showing marketing site while auth resolves')

--- a/components/ui/StructuredData.tsx
+++ b/components/ui/StructuredData.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useMemo } from 'react'
+import Script from 'next/script'
 
 interface StructuredDataProps {
   type: 'website' | 'organization' | 'webapp' | 'article' | 'faq' | 'financialService' | 'mobileApp'
@@ -24,10 +25,10 @@ export function StructuredData({ type, data }: StructuredDataProps) {
   }
 
   return (
-    <script
+    <Script
       id={`structured-data-${type}`}
       type="application/ld+json"
-      suppressHydrationWarning
+      strategy="afterInteractive"
       dangerouslySetInnerHTML={{ __html: schema }}
     />
   )


### PR DESCRIPTION
## Summary
- avoid hydration mismatch by waiting for client-side readiness before showing the marketing fallback while auth is loading
- use Next.js Script to inject structured data after hydration instead of rendering a raw script tag

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8f1da7cb483238226889cd24fcd4c