### PR TITLE
Remove inline JSON-LD script to prevent hydration failure

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -202,24 +202,7 @@ export default function RootLayout({
         <meta httpEquiv="X-XSS-Protection" content="1; mode=block" />
         <meta httpEquiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
         
-        {/* Structured Data */}
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              "@context": "https://schema.org",
-              "@type": "WebSite",
-              "name": "SplitSave",
-              "url": "https://splitsave.app",
-              "description": "Smart financial management app for couples to split expenses fairly and track savings goals together.",
-              "potentialAction": {
-                "@type": "SearchAction",
-                "target": "https://splitsave.app/search?q={search_term_string}",
-                "query-input": "required name=search_term_string"
-              }
-            })
-          }}
-        />
+        {/* Structured Data is handled by page-level components to avoid hydration mismatches */}
         
         {/* COMPREHENSIVE MOBILE FIX - Prevent white screen without breaking dark mode */}
         <style dangerouslySetInnerHTML={{


### PR DESCRIPTION
## Summary
- remove the inline structured data script from the app layout so the rendered head markup matches between server and client and avoids hydration failure on load

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8fa5a82488323a30f5e7a6bbae88d