### PR TITLE
Fix CTA analytics payload for mobile landing

### DIFF
--- a/components/mobile/MobileLandingPage.tsx
+++ b/components/mobile/MobileLandingPage.tsx
@@ -66,6 +66,7 @@ export function MobileLandingPage() {
     trackEvent('cta_clicked', {
       location: 'mobile_landing',
       cta_type: 'get_started',
+      page: 'mobile_landing',
       device: 'mobile_web'
     })
 
@@ -76,6 +77,7 @@ export function MobileLandingPage() {
     trackEvent('cta_clicked', {
       location: 'mobile_landing',
       cta_type: 'see_how_it_works',
+      page: 'mobile_landing',
       device: 'mobile_web'
     })
 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -9,7 +9,7 @@ export interface AnalyticsEvent {
   'user_logout': Record<string, never>
   
   // CRO & Conversion Events
-  'cta_clicked': { location: string; cta_type: string; page: string }
+  'cta_clicked': { location: string; cta_type: string; page: string; device?: string }
   'landing_page_view': { source: string; utm_campaign?: string; utm_source?: string }
   'signup_started': { method: string; source: string }
   'signup_completed': { method: string; time_to_complete: number }


### PR DESCRIPTION
## Summary
- include the page identifier when tracking CTA clicks on the mobile landing experience
- allow optional device metadata on cta_clicked analytics events so mobile tracking stays type-safe

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d95234772c832395fddcdca68086ce