### PR TITLE
Add unstyled mobile fallback for mobile marketing view

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import { StructuredData, structuredDataSchemas } from '@/components/ui/Structure
 import { useMobileDetection } from '@/hooks/useMobileDetection'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { analytics } from '@/lib/analytics'
-import { MobileLandingPage } from '@/components/mobile/MobileLandingPage'
+import { MobilePlainMarkup } from '@/components/mobile/MobilePlainMarkup'
 
 export default function Home() {
   const { user, loading } = useAuth()
@@ -183,14 +183,14 @@ export default function Home() {
 
   if (!user) {
     if (isClient && isMobile && !isStandalonePWA) {
-      console.log('📱 Home: Showing mobile marketing experience')
+      console.log('📱 Home: Showing unstyled mobile markup fallback')
       return (
         <>
           <StructuredData type="website" data={structuredDataSchemas.website} />
           <StructuredData type="organization" data={structuredDataSchemas.organization} />
           <StructuredData type="webapp" data={structuredDataSchemas.webapp} />
           <StructuredData type="financialService" data={structuredDataSchemas.financialService} />
-          <MobileLandingPage />
+          <MobilePlainMarkup />
         </>
       )
     }

--- a/components/mobile/MobilePlainMarkup.tsx
+++ b/components/mobile/MobilePlainMarkup.tsx
@@ -1,0 +1,43 @@
+export function MobilePlainMarkup() {
+  return (
+    <main>
+      <header>
+        <h1>SplitSave</h1>
+        <p>Smart financial management and savings goals for couples.</p>
+      </header>
+
+      <section>
+        <h2>Why SplitSave?</h2>
+        <ul>
+          <li>Share expenses fairly with proportional splits.</li>
+          <li>Track shared goals and celebrate milestones together.</li>
+          <li>Keep spending transparent without spreadsheets.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>What you can do</h2>
+        <ol>
+          <li>Create a shared account with your partner.</li>
+          <li>Log purchases in seconds and settle up whenever you need.</li>
+          <li>Plan upcoming bills and monitor progress towards savings goals.</li>
+        </ol>
+      </section>
+
+      <section>
+        <h2>Get started</h2>
+        <p>
+          Visit <a href="https://splitsave.app">splitsave.app</a> on a desktop or install the
+          SplitSave mobile app for the full experience.
+        </p>
+        <p>
+          Need help? Email <a href="mailto:hello@splitsave.app">hello@splitsave.app</a>.
+        </p>
+      </section>
+
+      <footer>
+        <p>&copy; {new Date().getFullYear()} SplitSave.</p>
+      </footer>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add a plain HTML fallback component that renders the marketing copy without styling
- update the mobile landing logic to serve the unstyled markup for non-PWA mobile visitors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d959f3635483239e72613802a772a8