### PR TITLE
Restore global Tailwind styles for mobile rendering

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,1 +1,33 @@
-/* Temporarily disable all global styling to allow testing the raw HTML rendering on mobile devices. */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  min-height: 100%;
+  background-color: #f9fafb;
+  font-family: var(--font-sans, 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+@media (prefers-color-scheme: dark) {
+  html,
+  body {
+    background-color: #0f172a;
+    color: #f8fafc;
+  }
+}


### PR DESCRIPTION
## Summary
- restore Tailwind base, components, and utilities directives in app/globals.css so utility classes render correctly
- add baseline mobile-friendly global styles to ensure readable typography and backgrounds in both light and dark modes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d95b76d2948323aac7b1566067f0eb