### PR TITLE
Ensure plain mobile fallback renders during auth loading

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import { StructuredData, structuredDataSchemas } from '@/components/ui/Structure
 import { useMobileDetection } from '@/hooks/useMobileDetection'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { analytics } from '@/lib/analytics'
-import { MobileLandingPage } from '@/components/mobile/MobileLandingPage'
+import { MobilePlainMarkup } from '@/components/mobile/MobilePlainMarkup'
 
 export default function Home() {
   const { user, loading } = useAuth()
@@ -150,6 +150,20 @@ export default function Home() {
 
   if (loading) {
     const shouldBypassLoading = isClient && hasAuthToken === false
+    const shouldShowPlainMobileFallback = isClient && isMobile && !isStandalonePWA
+
+    if (shouldShowPlainMobileFallback) {
+      console.log('📄 Loading mobile visitor detected - showing plain markup while auth resolves')
+      return (
+        <>
+          <StructuredData type="website" data={structuredDataSchemas.website} />
+          <StructuredData type="organization" data={structuredDataSchemas.organization} />
+          <StructuredData type="webapp" data={structuredDataSchemas.webapp} />
+          <StructuredData type="financialService" data={structuredDataSchemas.financialService} />
+          <MobilePlainMarkup />
+        </>
+      )
+    }
 
     if (shouldBypassLoading) {
       console.log('🚀 No stored session detected - showing marketing site while auth resolves')
@@ -169,8 +183,8 @@ export default function Home() {
             Mobile: {isMobile ? 'true' : 'false'} | Client: {isClient ? 'true' : 'false'}
           </div>
           <div className="mt-4 text-xs text-gray-400">
-            If this takes too long, <button 
-              onClick={() => window.location.reload()} 
+            If this takes too long, <button
+              onClick={() => window.location.reload()}
               className="text-purple-600 hover:text-purple-700 underline"
             >
               refresh the page
@@ -183,14 +197,14 @@ export default function Home() {
 
   if (!user) {
     if (isClient && isMobile && !isStandalonePWA) {
-      console.log('📱 Home: Showing mobile marketing experience')
+      console.log('📱 Home: Showing unstyled mobile markup fallback')
       return (
         <>
           <StructuredData type="website" data={structuredDataSchemas.website} />
           <StructuredData type="organization" data={structuredDataSchemas.organization} />
           <StructuredData type="webapp" data={structuredDataSchemas.webapp} />
           <StructuredData type="financialService" data={structuredDataSchemas.financialService} />
-          <MobileLandingPage />
+          <MobilePlainMarkup />
         </>
       )
     }

--- a/components/mobile/MobilePlainMarkup.tsx
+++ b/components/mobile/MobilePlainMarkup.tsx
@@ -1,0 +1,43 @@
+export function MobilePlainMarkup() {
+  return (
+    <main>
+      <header>
+        <h1>SplitSave</h1>
+        <p>Smart financial management and savings goals for couples.</p>
+      </header>
+
+      <section>
+        <h2>Why SplitSave?</h2>
+        <ul>
+          <li>Share expenses fairly with proportional splits.</li>
+          <li>Track shared goals and celebrate milestones together.</li>
+          <li>Keep spending transparent without spreadsheets.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>What you can do</h2>
+        <ol>
+          <li>Create a shared account with your partner.</li>
+          <li>Log purchases in seconds and settle up whenever you need.</li>
+          <li>Plan upcoming bills and monitor progress towards savings goals.</li>
+        </ol>
+      </section>
+
+      <section>
+        <h2>Get started</h2>
+        <p>
+          Visit <a href="https://splitsave.app">splitsave.app</a> on a desktop or install the
+          SplitSave mobile app for the full experience.
+        </p>
+        <p>
+          Need help? Email <a href="mailto:hello@splitsave.app">hello@splitsave.app</a>.
+        </p>
+      </section>
+
+      <footer>
+        <p>&copy; {new Date().getFullYear()} SplitSave.</p>
+      </footer>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- render the plain mobile fallback while authentication is still loading for non-PWA mobile visitors
- keep structured data tags in place when serving the unstyled markup

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d959f3635483239e72613802a772a8