### PR TITLE
Show styled mobile landing page on mobile web

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,1 +1,33 @@
-/* Temporarily disable all global styling to allow testing the raw HTML rendering on mobile devices. */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  min-height: 100%;
+  background-color: #f9fafb;
+  font-family: var(--font-sans, 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+}
+
+body {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+@media (prefers-color-scheme: dark) {
+  html,
+  body {
+    background-color: #0f172a;
+    color: #f8fafc;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { StructuredData, structuredDataSchemas } from '@/components/ui/Structure
 import { useMobileDetection } from '@/hooks/useMobileDetection'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { analytics } from '@/lib/analytics'
+import { MobileLandingPage } from '@/components/mobile/MobileLandingPage'
 import { MobilePlainMarkup } from '@/components/mobile/MobilePlainMarkup'
 
 export default function Home() {
@@ -183,14 +184,18 @@ export default function Home() {
 
   if (!user) {
     if (isClient && isMobile && !isStandalonePWA) {
-      console.log('📱 Home: Showing unstyled mobile markup fallback')
+      console.log('📱 Home: Showing tailored mobile landing experience')
+
       return (
         <>
           <StructuredData type="website" data={structuredDataSchemas.website} />
           <StructuredData type="organization" data={structuredDataSchemas.organization} />
           <StructuredData type="webapp" data={structuredDataSchemas.webapp} />
           <StructuredData type="financialService" data={structuredDataSchemas.financialService} />
-          <MobilePlainMarkup />
+          <MobileLandingPage />
+          <noscript>
+            <MobilePlainMarkup />
+          </noscript>
         </>
       )
     }


### PR DESCRIPTION
## Summary
- serve the rich Tailwind-powered mobile landing experience instead of the plain fallback when visiting on mobile web
- keep the plain HTML markup inside a `<noscript>` block as an accessibility fallback if JavaScript is disabled

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d95b76d2948323aac7b1566067f0eb