### PR TITLE
feat: align mobile landing with pwa preview

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -250,38 +250,6 @@ export default function Home() {
   // TEMPORARY: Add mobile website test
   if (isMobile && !isStandalonePWA) {
     console.log('📱 Mobile website detected (not PWA)', { isMobile, isStandalonePWA })
-    return (
-      <>
-        <div className="pointer-events-none fixed inset-x-0 top-4 z-50 flex justify-center px-4 sm:px-6">
-          <div className="pointer-events-auto w-full max-w-sm rounded-2xl border border-blue-100/60 bg-white/90 p-4 text-left shadow-lg backdrop-blur-sm dark:border-blue-800/50 dark:bg-gray-900/85">
-            <p className="text-sm font-semibold text-blue-600 dark:text-blue-300">Mobile website</p>
-            <p className="mt-1 text-xs text-gray-600 dark:text-gray-300">
-              You're viewing SplitSave in the browser. Add it to your home screen for the full PWA experience.
-            </p>
-            <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-gray-500 dark:text-gray-400">
-              <div>
-                <dt className="font-medium text-gray-700 dark:text-gray-200">Mobile</dt>
-                <dd>{isMobile ? 'Yes' : 'No'}</dd>
-              </div>
-              <div>
-                <dt className="font-medium text-gray-700 dark:text-gray-200">Standalone</dt>
-                <dd>{isStandalonePWA ? 'Yes' : 'No'}</dd>
-              </div>
-              <div>
-                <dt className="font-medium text-gray-700 dark:text-gray-200">User</dt>
-                <dd>{user ? 'Logged in' : 'Not logged in'}</dd>
-              </div>
-              <div>
-                <dt className="font-medium text-gray-700 dark:text-gray-200">Client ready</dt>
-                <dd>{isClient ? 'Yes' : 'No'}</dd>
-              </div>
-            </dl>
-          </div>
-        </div>
-
-        <SplitsaveApp />
-      </>
-    )
   }
 
   return (

--- a/components/mobile/MobileLandingPage.tsx
+++ b/components/mobile/MobileLandingPage.tsx
@@ -1,30 +1,9 @@
 'use client'
 
-import { useState } from 'react'
-import { motion } from 'framer-motion'
+import { useEffect, useState } from 'react'
 import { LoginForm } from '@/components/auth/LoginForm'
 import { trackEvent } from '@/lib/analytics'
-
-const featureCards = [
-  {
-    icon: '🤝',
-    title: 'Made for partners',
-    description:
-      'Split every bill proportionally, log shared purchases in seconds, and see who owes what at a glance.'
-  },
-  {
-    icon: '🎯',
-    title: 'Shared goals that stick',
-    description:
-      'Turn big plans into funded milestones with collaborative goals, nudges, and automatic celebrations.'
-  },
-  {
-    icon: '📊',
-    title: 'Clarity without spreadsheets',
-    description:
-      'Real-time dashboards replace awkward money chats with always-on transparency and receipts.'
-  }
-]
+import { useMobileDetection } from '@/hooks/useMobileDetection'
 
 const roadmapItems = [
   {
@@ -61,11 +40,19 @@ const sellingPoints = [
 
 export function MobileLandingPage() {
   const [showLogin, setShowLogin] = useState(false)
+  const [showSafariGuide, setShowSafariGuide] = useState(false)
+  const { isMobileSafari } = useMobileDetection()
+
+  useEffect(() => {
+    if (!isMobileSafari && showSafariGuide) {
+      setShowSafariGuide(false)
+    }
+  }, [isMobileSafari, showSafariGuide])
 
   const handlePrimaryCta = () => {
     trackEvent('cta_clicked', {
       location: 'mobile_landing',
-      cta_type: 'get_started',
+      cta_type: 'log_in_mobile_web',
       page: 'mobile_landing',
       device: 'mobile_web'
     })
@@ -85,182 +72,200 @@ export function MobileLandingPage() {
     section?.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }
 
+  const handleSafariInstallToggle = () => {
+    setShowSafariGuide((prev) => {
+      const next = !prev
+      trackEvent('cta_clicked', {
+        location: 'mobile_landing',
+        cta_type: next ? 'open_safari_install_guide' : 'close_safari_install_guide',
+        page: 'mobile_landing',
+        device: 'mobile_web'
+      })
+      return next
+    })
+  }
+
   if (showLogin) {
     return <LoginForm onBack={() => setShowLogin(false)} />
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-purple-900 via-indigo-900 to-gray-950 text-white">
-      <div className="absolute inset-0 overflow-hidden">
-        <div className="absolute -top-24 -right-24 h-72 w-72 rounded-full bg-purple-500/40 blur-3xl" />
-        <div className="absolute -bottom-32 -left-16 h-80 w-80 rounded-full bg-blue-500/30 blur-3xl" />
+    <div className="min-h-screen bg-slate-950 text-white">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-32 right-0 h-72 w-72 rounded-full bg-purple-600/30 blur-3xl" />
+        <div className="absolute bottom-[-20%] left-[-10%] h-80 w-80 rounded-full bg-blue-500/20 blur-3xl" />
       </div>
 
-      <div className="relative mx-auto flex min-h-screen max-w-lg flex-col">
-        <header className="px-6 pt-16 pb-10 text-center">
+      <div className="relative mx-auto flex min-h-screen max-w-md flex-col">
+        <header className="px-6 pt-16 pb-8 text-center">
           <p className="text-xs font-semibold uppercase tracking-[0.35em] text-purple-200/80">SplitSave mobile</p>
-          <motion.h1
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            className="mt-6 text-4xl font-bold leading-tight"
-          >
-            The easiest way to stay synced on money together
-          </motion.h1>
-          <motion.p
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.1 }}
-            className="mt-4 text-base text-purple-100/90"
-          >
-            Track shared spending, see progress towards your goals, and celebrate wins in a layout crafted just for phones.
-          </motion.p>
+          <h1 className="mt-6 text-3xl font-semibold leading-snug text-white">
+            Everything you love in the SplitSave app—right in Safari
+          </h1>
+          <p className="mt-4 text-sm text-purple-100/80">
+            The mobile web experience mirrors the PWA so you can check balances, track shared purchases, and fund goals without installing anything extra.
+          </p>
 
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.2 }}
-            className="mt-8 flex flex-col gap-3"
-          >
+          <div className="mt-8 flex flex-col gap-3">
             <button
               type="button"
               onClick={handlePrimaryCta}
-              className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-base font-semibold text-purple-900 shadow-xl shadow-purple-900/30 transition hover:translate-y-0.5 hover:bg-purple-50"
+              className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-base font-semibold text-purple-900 shadow-lg shadow-purple-900/30 transition hover:-translate-y-0.5 hover:bg-purple-50"
             >
-              Start free with your partner
+              Log in to SplitSave
             </button>
             <button
               type="button"
               onClick={handleSecondaryCta}
-              className="inline-flex items-center justify-center rounded-full border border-white/30 px-6 py-3 text-base font-semibold text-white transition hover:border-white hover:bg-white/10"
+              className="inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-base font-semibold text-white/90 transition hover:border-white hover:text-white"
             >
-              See how SplitSave feels
+              Explore the web app preview
             </button>
-          </motion.div>
-
-          <div className="mt-10 flex items-center justify-center gap-3 text-xs text-purple-100/80">
-            <div className="flex -space-x-2">
-              {[0, 1, 2, 3].map((item) => (
-                <div key={item} className="h-8 w-8 rounded-full bg-gradient-to-br from-purple-300 to-blue-300 ring-2 ring-purple-900/60" />
-              ))}
-            </div>
-            <span>4.9★ from the couples who helped us build it</span>
           </div>
+
+          {isMobileSafari && (
+            <div className="mt-6 rounded-3xl border border-white/10 bg-white/5 p-5 text-left shadow-xl backdrop-blur-sm">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-purple-100/90">Add SplitSave to your Home Screen</p>
+                  <p className="mt-1 text-xs text-purple-100/70">
+                    Install the mobile web app for a true full-screen experience with offline support.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={handleSafariInstallToggle}
+                  className="inline-flex items-center justify-center rounded-full bg-white/20 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+                  aria-expanded={showSafariGuide}
+                >
+                  {showSafariGuide ? 'Hide steps' : 'Install'}
+                </button>
+              </div>
+              {showSafariGuide && (
+                <ol className="mt-4 space-y-2 rounded-2xl border border-white/10 bg-black/20 p-4 text-xs text-purple-100/80">
+                  <li>Tap the <strong>Share</strong> icon in Safari.</li>
+                  <li>Choose <strong>Add to Home Screen</strong>.</li>
+                  <li>Confirm the name “SplitSave” and tap <strong>Add</strong>.</li>
+                </ol>
+              )}
+            </div>
+          )}
         </header>
 
-        <main className="flex-1 space-y-16 px-6 pb-32">
-          <section className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-            <div className="mb-6 flex items-center gap-3 text-sm uppercase tracking-widest text-purple-200/80">
-              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-white/10 text-lg">⚡</span>
-              Real-time balance for both of you
-            </div>
-            <div className="grid gap-4 text-left text-sm text-purple-100/90">
-              <div className="rounded-2xl bg-white/10 p-4">
-                <div className="flex items-center justify-between text-xs text-purple-200/80">
-                  <span>This week</span>
-                  <span>Shared wallet</span>
-                </div>
-                <div className="mt-4 text-3xl font-semibold text-white">£482.20</div>
-                <div className="mt-1 text-xs text-purple-200/70">You are ahead by £24.18</div>
-              </div>
-              <div className="grid grid-cols-2 gap-3 text-xs">
-                <div className="rounded-2xl bg-white/10 p-4">
-                  <p className="text-purple-200/80">Upcoming</p>
-                  <p className="mt-3 text-base font-semibold text-white">Rent payout · £1,200</p>
-                  <p className="mt-2 text-purple-200/70">Split 40% / 60%</p>
-                </div>
-                <div className="rounded-2xl bg-white/10 p-4">
-                  <p className="text-purple-200/80">Goal streak</p>
-                  <p className="mt-3 text-3xl font-semibold text-green-200">18 days</p>
-                  <p className="mt-2 text-purple-200/70">Holiday fund 72% complete</p>
-                </div>
-              </div>
-            </div>
+        <main className="flex-1 space-y-14 px-6 pb-20">
+          <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-purple-900/30 backdrop-blur">
+            <p className="text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-purple-100/70">Live preview</p>
+            <h2 className="mt-3 text-2xl font-semibold text-white/95">This is what the SplitSave web app looks like</h2>
+            <p className="mt-3 text-sm text-purple-100/80">
+              Navigate the same cards, balances, and activity feed you see in the installed PWA—no more blank screens.
+            </p>
+
+            <AppShellPreview />
           </section>
 
-          <section className="space-y-6">
-            <h2 className="text-2xl font-semibold">Why couples stick with SplitSave</h2>
-            <div className="space-y-4">
-              {featureCards.map((feature) => (
-                <div key={feature.title} className="rounded-3xl border border-white/10 bg-white/5 p-5 backdrop-blur">
-                  <div className="flex items-center gap-3">
-                    <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-white/10 text-xl">{feature.icon}</span>
-                    <div>
-                      <p className="text-sm font-semibold uppercase tracking-wide text-purple-200/80">{feature.title}</p>
-                      <p className="mt-2 text-sm text-purple-100/90">{feature.description}</p>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          <section id="mobile-how-it-works" className="space-y-6">
-            <h2 className="text-2xl font-semibold">How it works</h2>
-            <ol className="space-y-4 text-sm text-purple-100/90">
-              <li className="rounded-3xl border border-white/10 bg-white/5 p-5 backdrop-blur">
-                <p className="text-xs font-semibold uppercase tracking-widest text-purple-200/70">Step 1</p>
-                <p className="mt-2 text-base font-semibold text-white">Invite your partner and connect shared expenses</p>
-                <p className="mt-2 text-sm">SplitSave auto-suggests fair splits and who should press pay.</p>
-              </li>
-              <li className="rounded-3xl border border-white/10 bg-white/5 p-5 backdrop-blur">
-                <p className="text-xs font-semibold uppercase tracking-widest text-purple-200/70">Step 2</p>
-                <p className="mt-2 text-base font-semibold text-white">Set savings missions that feel exciting</p>
-                <p className="mt-2 text-sm">Pick a goal, choose how much each contributes, and track progress together.</p>
-              </li>
-              <li className="rounded-3xl border border-white/10 bg-white/5 p-5 backdrop-blur">
-                <p className="text-xs font-semibold uppercase tracking-widest text-purple-200/70">Step 3</p>
-                <p className="mt-2 text-base font-semibold text-white">Celebrate, adjust, and stay in sync</p>
-                <p className="mt-2 text-sm">Automatic reminders and shared updates keep both of you aligned without awkward chats.</p>
-              </li>
-            </ol>
-          </section>
-
-          <section className="space-y-4">
-            <h2 className="text-2xl font-semibold">Built for what&apos;s next</h2>
-            <div className="grid gap-4">
-              {roadmapItems.map((item) => (
-                <div key={item.title} className="rounded-3xl border border-white/10 bg-white/5 p-5 backdrop-blur">
-                  <p className="text-xs font-semibold uppercase tracking-[0.35em] text-purple-200/70">{item.label}</p>
-                  <p className="mt-3 text-lg font-semibold text-white">{item.title}</p>
-                  <p className="mt-2 text-sm text-purple-100/90">{item.copy}</p>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          <section className="space-y-4">
-            <h2 className="text-2xl font-semibold">Everything couples asked for</h2>
-            <div className="space-y-3 text-sm text-purple-100/90">
+          <section id="mobile-how-it-works" className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-purple-900/30 backdrop-blur">
+            <p className="text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-purple-100/70">Why it matches the PWA</p>
+            <h2 className="mt-3 text-2xl font-semibold text-white/95">Full fidelity budgeting on the go</h2>
+            <div className="mt-6 space-y-5">
               {sellingPoints.map((point) => (
-                <div key={point.title} className="flex items-start gap-3 rounded-3xl border border-white/10 bg-white/5 p-4 backdrop-blur">
-                  <span className="mt-1 text-lg text-green-200">✓</span>
-                  <div>
-                    <p className="text-sm font-semibold text-white">{point.title}</p>
-                    <p className="mt-1 text-sm">{point.description}</p>
-                  </div>
+                <div key={point.title} className="rounded-2xl border border-white/10 bg-black/20 p-4">
+                  <p className="text-sm font-semibold text-white/90">{point.title}</p>
+                  <p className="mt-2 text-xs text-purple-100/70">{point.description}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-purple-900/30 backdrop-blur">
+            <p className="text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-purple-100/70">Roadmap</p>
+            <h2 className="mt-3 text-2xl font-semibold text-white/95">SplitSave keeps evolving</h2>
+            <div className="mt-6 space-y-5">
+              {roadmapItems.map((item) => (
+                <div key={item.label} className="rounded-2xl border border-white/10 bg-black/20 p-4">
+                  <p className="text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-purple-100/70">{item.label}</p>
+                  <p className="mt-2 text-sm font-semibold text-white/90">{item.title}</p>
+                  <p className="mt-1 text-xs text-purple-100/70">{item.copy}</p>
                 </div>
               ))}
             </div>
           </section>
         </main>
 
-        <div className="sticky bottom-0 border-t border-white/10 bg-gradient-to-t from-purple-950/95 to-purple-900/60 px-6 py-6 backdrop-blur">
-          <div className="flex flex-col gap-3 text-center">
-            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-purple-200/80">Ready to sync up?</p>
-            <button
-              type="button"
-              onClick={handlePrimaryCta}
-              className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-base font-semibold text-purple-900 shadow-xl shadow-purple-900/30 transition hover:bg-purple-50"
-            >
-              Create your shared space now
-            </button>
-            <p className="text-[11px] text-purple-100/70">
-              No credit card required · Works great on desktop too
-            </p>
+        <footer className="px-6 pb-12 text-center text-[0.7rem] text-purple-100/60">
+          &copy; {new Date().getFullYear()} SplitSave. All rights reserved.
+        </footer>
+      </div>
+    </div>
+  )
+}
+
+function AppShellPreview() {
+  return (
+    <div className="mt-6 rounded-2xl border border-white/10 bg-slate-900/80 p-4 shadow-inner">
+      <div className="rounded-xl bg-slate-950 p-4 text-left">
+        <div className="flex items-start justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-purple-200/70">Shared balance</p>
+            <p className="mt-1 text-2xl font-semibold text-white">$4,380.42</p>
           </div>
+          <span className="rounded-full bg-emerald-500/20 px-3 py-1 text-[0.65rem] font-semibold text-emerald-300">On track</span>
+        </div>
+
+        <div className="mt-5 grid gap-3">
+          <PreviewCard
+            title="This week"
+            amount="$612.20"
+            description="Groceries, date nights, and shared subscriptions"
+          />
+          <PreviewCard
+            title="Upcoming bills"
+            amount="$940.00"
+            description="Rent, utilities, and sinking funds for travel"
+          />
+        </div>
+
+        <div className="mt-6 rounded-lg border border-white/10 bg-black/30 p-3">
+          <p className="text-xs font-semibold text-purple-100/80">Activity feed</p>
+          <ul className="mt-3 space-y-3 text-xs text-purple-100/70">
+            <li>
+              <span className="font-semibold text-white/90">Jordan</span> added a grocery run • Split 60/40
+            </li>
+            <li>
+              <span className="font-semibold text-white/90">Riley</span> funded the &ldquo;Weekend getaway&rdquo; goal
+            </li>
+            <li>Auto-transfer scheduled for Monday</li>
+          </ul>
+        </div>
+
+        <div className="mt-6 grid grid-cols-2 gap-3 text-xs">
+          <button className="rounded-full bg-purple-600/90 px-3 py-2 font-semibold text-white transition hover:bg-purple-500">
+            Add purchase
+          </button>
+          <button className="rounded-full border border-white/10 px-3 py-2 font-semibold text-white/90 transition hover:border-white/20">
+            Add to goal
+          </button>
         </div>
       </div>
+    </div>
+  )
+}
+
+function PreviewCard({
+  title,
+  amount,
+  description
+}: {
+  title: string
+  amount: string
+  description: string
+}) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/30 p-3">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-purple-100/70">{title}</p>
+        <p className="text-sm font-semibold text-white/90">{amount}</p>
+      </div>
+      <p className="mt-2 text-[0.7rem] text-purple-100/70">{description}</p>
     </div>
   )
 }

--- a/components/mobile/MobilePlainMarkup.tsx
+++ b/components/mobile/MobilePlainMarkup.tsx
@@ -1,42 +1,47 @@
 export function MobilePlainMarkup() {
   return (
-    <main>
-      <header>
-        <h1>SplitSave</h1>
-        <p>Smart financial management and savings goals for couples.</p>
+    <main style={{ fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif', padding: '2.5rem 1.75rem', maxWidth: 480, margin: '0 auto', color: '#111827' }}>
+      <header style={{ textAlign: 'center', marginBottom: '2.5rem' }}>
+        <p style={{ textTransform: 'uppercase', letterSpacing: '0.35em', fontSize: '0.65rem', color: '#7c3aed', fontWeight: 600 }}>SplitSave mobile</p>
+        <h1 style={{ fontSize: '1.9rem', lineHeight: 1.25, marginTop: '0.75rem', marginBottom: '0.75rem' }}>SplitSave web app preview</h1>
+        <p style={{ fontSize: '0.95rem', color: '#4b5563' }}>
+          You&apos;re viewing the lightweight mobile web experience. It mirrors the SplitSave PWA so you can keep tabs on balances, purchases, and shared goals from Safari.
+        </p>
       </header>
 
-      <section>
-        <h2>Why SplitSave?</h2>
-        <ul>
-          <li>Share expenses fairly with proportional splits.</li>
-          <li>Track shared goals and celebrate milestones together.</li>
-          <li>Keep spending transparent without spreadsheets.</li>
+      <section style={{ background: '#f9fafb', borderRadius: '1.5rem', padding: '1.75rem', marginBottom: '2rem', border: '1px solid #e5e7eb' }}>
+        <h2 style={{ fontSize: '1.15rem', fontWeight: 600, marginBottom: '0.75rem' }}>What you can do</h2>
+        <ul style={{ listStyle: 'disc', paddingLeft: '1.25rem', fontSize: '0.95rem', color: '#4b5563', lineHeight: 1.6 }}>
+          <li>Log purchases in seconds and see who owes what in real time.</li>
+          <li>Review balances, transfer suggestions, and shared activity at a glance.</li>
+          <li>Continue funding goals and celebrating progress without the app installed.</li>
         </ul>
       </section>
 
-      <section>
-        <h2>What you can do</h2>
-        <ol>
-          <li>Create a shared account with your partner.</li>
-          <li>Log purchases in seconds and settle up whenever you need.</li>
-          <li>Plan upcoming bills and monitor progress towards savings goals.</li>
+      <section style={{ background: '#f5f3ff', borderRadius: '1.5rem', padding: '1.75rem', marginBottom: '2rem', border: '1px solid #ddd6fe' }}>
+        <h2 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '0.5rem', color: '#5b21b6' }}>Add SplitSave to your Home Screen</h2>
+        <ol style={{ listStyle: 'decimal', paddingLeft: '1.25rem', fontSize: '0.95rem', color: '#4b5563', lineHeight: 1.6 }}>
+          <li>Tap the <strong>Share</strong> icon in Safari.</li>
+          <li>Select <strong>Add to Home Screen</strong>.</li>
+          <li>Confirm the name “SplitSave” and tap <strong>Add</strong>.</li>
         </ol>
-      </section>
-
-      <section>
-        <h2>Get started</h2>
-        <p>
-          Visit <a href="https://splitsave.app">splitsave.app</a> on a desktop or install the
-          SplitSave mobile app for the full experience.
-        </p>
-        <p>
-          Need help? Email <a href="mailto:hello@splitsave.app">hello@splitsave.app</a>.
+        <p style={{ fontSize: '0.85rem', color: '#6b7280', marginTop: '0.75rem' }}>
+          Installing gives you the same full-screen experience as the native app with offline support.
         </p>
       </section>
 
-      <footer>
-        <p>&copy; {new Date().getFullYear()} SplitSave.</p>
+      <section style={{ background: '#ecfeff', borderRadius: '1.5rem', padding: '1.75rem', marginBottom: '2rem', border: '1px solid #bae6fd' }}>
+        <h2 style={{ fontSize: '1.1rem', fontWeight: 600, marginBottom: '0.5rem', color: '#0369a1' }}>Need to jump into the app?</h2>
+        <p style={{ fontSize: '0.95rem', color: '#0f172a', lineHeight: 1.6 }}>
+          Visit <a href="https://splitsave.app" style={{ color: '#2563eb', textDecoration: 'underline' }}>splitsave.app</a> on desktop or continue in Safari—the same secure experience is now available on mobile web.
+        </p>
+        <p style={{ fontSize: '0.85rem', color: '#475569', marginTop: '0.75rem' }}>
+          Questions? Email <a href="mailto:hello@splitsave.app" style={{ color: '#2563eb', textDecoration: 'underline' }}>hello@splitsave.app</a> and we&apos;ll help you get set up.
+        </p>
+      </section>
+
+      <footer style={{ textAlign: 'center', fontSize: '0.75rem', color: '#9ca3af' }}>
+        &copy; {new Date().getFullYear()} SplitSave. All rights reserved.
       </footer>
     </main>
   )

--- a/hooks/useMobileDetection.ts
+++ b/hooks/useMobileDetection.ts
@@ -8,6 +8,8 @@ interface MobileDetection {
   isClient: boolean
   userAgent: string
   screenSize: string
+  isIOS: boolean
+  isMobileSafari: boolean
 }
 
 export function useMobileDetection(): MobileDetection {
@@ -16,7 +18,9 @@ export function useMobileDetection(): MobileDetection {
     isSmallScreen: false,
     isClient: false,
     userAgent: '',
-    screenSize: ''
+    screenSize: '',
+    isIOS: false,
+    isMobileSafari: false
   })
 
   useEffect(() => {
@@ -29,34 +33,44 @@ export function useMobileDetection(): MobileDetection {
     const screenSize = `${window.innerWidth}x${window.innerHeight}`
     
     // Additional iOS detection
-    const isIOS = /iPad|iPhone|iPod/.test(userAgent) || 
-                  (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+    const isIOS =
+      /iPad|iPhone|iPod/.test(userAgent) ||
+      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+    const isSafari = /^((?!chrome|android).)*safari/i.test(userAgent)
+    const isMobileSafari = isSafari && isIOS
     
     console.log('🔍 Mobile Detection:', {
       userAgent: userAgent.substring(0, 100),
       isMobile,
       isSmallScreen,
       isIOS,
+      isMobileSafari,
       screenSize,
       platform: navigator.platform,
       maxTouchPoints: navigator.maxTouchPoints
     })
 
     setDetection({
-      isMobile,
+      isMobile: isMobile || isSmallScreen,
       isSmallScreen,
       isClient: true,
       userAgent,
-      screenSize
+      screenSize,
+      isIOS,
+      isMobileSafari
     })
 
     // Listen for resize events
     const handleResize = () => {
-      setDetection(prev => ({
-        ...prev,
-        isSmallScreen: window.innerWidth <= 768,
-        screenSize: `${window.innerWidth}x${window.innerHeight}`
-      }))
+      setDetection((prev) => {
+        const nextIsSmallScreen = window.innerWidth <= 768
+        return {
+          ...prev,
+          isSmallScreen: nextIsSmallScreen,
+          screenSize: `${window.innerWidth}x${window.innerHeight}`,
+          isMobile: prev.isMobile || nextIsSmallScreen
+        }
+      })
     }
 
     window.addEventListener('resize', handleResize)


### PR DESCRIPTION
## Summary
- replace the mobile Safari landing screen with a static SplitSave app preview that mirrors the PWA layout and preserves install guidance
- update the plain markup fallback to surface feature copy and home screen install steps instead of leaving a blank screen

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9646692e48323817c31e6d8f2ea6f