### PR TITLE
Fix Jest test discovery patterns

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -40,8 +40,9 @@ const customJestConfig = {
     '^.+\\.module\\.(css|sass|scss)$',
   ],
   testMatch: [
-    '**/__tests__/**/*.(test|spec).(ts|tsx|js)',
-    '**/*.(test|spec).(ts|tsx|js)',
+    '**/__tests__/**/*.test.[tj]s?(x)',
+    '**/__tests__/**/*.spec.[tj]s?(x)',
+    '**/?(*.)+(test|spec).[tj]s?(x)',
   ],
 }
 


### PR DESCRIPTION
## Summary
- correct the Jest `testMatch` configuration so component and utility tests are discovered

## Testing
- `npm test -- --runTestsByPath __tests__/components/LoginForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68d98541dfe083238c8c7f0af0f63665