### PR TITLE
Fix gradient overlay blocking mobile landing content

### DIFF
--- a/components/mobile/MobileLandingPage.tsx
+++ b/components/mobile/MobileLandingPage.tsx
@@ -90,8 +90,11 @@ export function MobileLandingPage() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-950 text-white">
-      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+    <div className="relative min-h-screen bg-slate-950 text-white">
+      <div
+        className="pointer-events-none absolute inset-0 -z-10 overflow-hidden"
+        aria-hidden="true"
+      >
         <div className="absolute -top-32 right-0 h-72 w-72 rounded-full bg-purple-600/30 blur-3xl" />
         <div className="absolute bottom-[-20%] left-[-10%] h-80 w-80 rounded-full bg-blue-500/20 blur-3xl" />
       </div>


### PR DESCRIPTION
## Summary
- make the mobile landing page container positioned relative so decorative layers stay scoped
- send the background gradient layer behind the content with a negative z-index and mark it aria-hidden to avoid intercepting taps

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d99713f7d88323a792d409abed3add