### PR TITLE
Handle invite email failures by surfacing shareable link

### DIFF
--- a/supabase/functions/send-invitation-email/index.ts
+++ b/supabase/functions/send-invitation-email/index.ts
@@ -22,12 +22,13 @@ serve(async (req)=>{
       throw new Error('Invalid service role key');
     }
     // Get the invitation data from the request
-    const { invitationId, toEmail, fromUserName, fromUserEmail } = await req.json();
+    const { invitationId, toEmail, fromUserName, fromUserEmail, invitationLink: providedLink } = await req.json();
     if (!invitationId || !toEmail || !fromUserName || !fromUserEmail) {
       throw new Error('Missing required fields');
     }
     // Create the invitation link
-    const invitationLink = `${Deno.env.get('FRONTEND_URL') || 'https://splitsave.community'}/api/invite/accept/${invitationId}`;
+    const defaultLink = `${Deno.env.get('FRONTEND_URL') || 'https://splitsave.community'}/api/invite/accept/${invitationId}`;
+    const invitationLink = providedLink || defaultLink;
     // Email template
     const emailHtml = `
       <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- generate a joint invite link during invite creation and return email delivery status information
- update the partnership manager UI to warn when email delivery fails and provide a clipboard/share fallback
- allow the send-invitation email function to respect pre-generated invite links

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da700796748323b871be3852971db6