### PR TITLE
Disable mobile web experience on mobile devices

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,8 +7,7 @@ import { StructuredData, structuredDataSchemas } from '@/components/ui/Structure
 import { useMobileDetection } from '@/hooks/useMobileDetection'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { analytics } from '@/lib/analytics'
-import { MobileLandingPage } from '@/components/mobile/MobileLandingPage'
-import { MobilePlainMarkup } from '@/components/mobile/MobilePlainMarkup'
+import { MobileTestingScreen } from '@/components/mobile/MobileTestingScreen'
 
 export default function Home() {
   const { user, loading } = useAuth()
@@ -16,6 +15,7 @@ export default function Home() {
   const [isStandalonePWA, setIsStandalonePWA] = useState(false)
   const [hasAuthToken, setHasAuthToken] = useState<boolean | null>(null)
   const { isMobile, isSmallScreen, isClient } = useMobileDetection()
+  const shouldShowMobileTesting = isClient && (isMobile || isSmallScreen) && !isStandalonePWA
 
   const checkStoredAuthToken = useCallback(() => {
     if (typeof window === 'undefined') {
@@ -151,17 +151,16 @@ export default function Home() {
 
   if (loading) {
     const shouldBypassLoading = isClient && hasAuthToken === false
-    const shouldShowPlainMobileFallback = isClient && isMobile && !isStandalonePWA
 
-    if (shouldShowPlainMobileFallback) {
-      console.log('📄 Loading mobile visitor detected - showing plain markup while auth resolves')
+    if (shouldShowMobileTesting) {
+      console.log('🛠️ Loading mobile visitor detected - showing testing screen')
       return (
         <>
           <StructuredData type="website" data={structuredDataSchemas.website} />
           <StructuredData type="organization" data={structuredDataSchemas.organization} />
           <StructuredData type="webapp" data={structuredDataSchemas.webapp} />
           <StructuredData type="financialService" data={structuredDataSchemas.financialService} />
-          <MobilePlainMarkup />
+          <MobileTestingScreen variant="loading" />
         </>
       )
     }
@@ -197,8 +196,8 @@ export default function Home() {
   }
 
   if (!user) {
-    if (isClient && isMobile && !isStandalonePWA) {
-      console.log('📱 Home: Showing tailored mobile landing experience')
+    if (shouldShowMobileTesting) {
+      console.log('📱 Home: Showing mobile testing screen for visitor without session')
 
       return (
         <>
@@ -206,10 +205,7 @@ export default function Home() {
           <StructuredData type="organization" data={structuredDataSchemas.organization} />
           <StructuredData type="webapp" data={structuredDataSchemas.webapp} />
           <StructuredData type="financialService" data={structuredDataSchemas.financialService} />
-          <MobileLandingPage />
-          <noscript>
-            <MobilePlainMarkup />
-          </noscript>
+          <MobileTestingScreen />
         </>
       )
     }
@@ -221,12 +217,26 @@ export default function Home() {
   }
 
   // For mobile devices, add additional safety check
-  if (isClient && (isMobile || isSmallScreen)) {
-    console.log('🔍 Mobile device detected, rendering SplitsaveApp', { isMobile, isSmallScreen, hasUser: !!user })
+  if (shouldShowMobileTesting) {
+    console.log('🛠️ Mobile device detected - showing testing screen for authenticated user', {
+      isMobile,
+      isSmallScreen,
+      hasUser: !!user
+    })
+
+    return (
+      <>
+        <StructuredData type="website" data={structuredDataSchemas.website} />
+        <StructuredData type="organization" data={structuredDataSchemas.organization} />
+        <StructuredData type="webapp" data={structuredDataSchemas.webapp} />
+        <StructuredData type="financialService" data={structuredDataSchemas.financialService} />
+        <MobileTestingScreen />
+      </>
+    )
   }
 
-  console.log('🏠 Home: Rendering SplitsaveApp', { 
-    hasUser: !!user, 
+  console.log('🏠 Home: Rendering SplitsaveApp', {
+    hasUser: !!user,
     userEmail: user?.email,
     userId: user?.id,
     loading,

--- a/components/mobile/MobileTestingScreen.tsx
+++ b/components/mobile/MobileTestingScreen.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+interface MobileTestingScreenProps {
+  variant?: 'default' | 'loading'
+}
+
+export function MobileTestingScreen({ variant = 'default' }: MobileTestingScreenProps) {
+  const headline =
+    variant === 'loading'
+      ? 'Mobile experience under maintenance'
+      : 'Mobile web experience under maintenance'
+
+  const description =
+    variant === 'loading'
+      ? 'We’re currently diagnosing mobile loading issues. Please check back soon or use SplitSave on desktop.'
+      : 'The mobile website is temporarily disabled while we debug loading issues. SplitSave is still available on desktop.'
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-purple-50 via-white to-white dark:from-gray-950 dark:via-gray-900 dark:to-gray-900 flex items-center justify-center px-6 py-16">
+      <div className="w-full max-w-md rounded-3xl border border-purple-100/60 bg-white/85 p-10 text-center shadow-xl backdrop-blur dark:border-purple-900/40 dark:bg-gray-900/80">
+        <p className="text-sm font-semibold uppercase tracking-wide text-purple-600 dark:text-purple-300">SplitSave mobile</p>
+        <h1 className="mt-4 text-2xl font-bold text-gray-900 dark:text-white">{headline}</h1>
+        <p className="mt-4 text-base text-gray-600 dark:text-gray-300">{description}</p>
+        <div className="mt-6 rounded-2xl bg-purple-50/80 px-4 py-3 text-sm text-purple-900 dark:bg-purple-950/40 dark:text-purple-100">
+          <p className="font-medium">Why am I seeing this?</p>
+          <p className="mt-1 text-xs text-purple-800/90 dark:text-purple-100/80">
+            The production mobile site was failing to load in Safari and Chrome on iOS. We&apos;ve disabled the mobile
+            experience while we run tests and fixes. Please continue on desktop for now.
+          </p>
+        </div>
+        <p className="mt-6 text-xs text-gray-500 dark:text-gray-400">
+          Need access urgently? Email <a className="font-semibold text-purple-600 hover:text-purple-500" href="mailto:team@splitsave.community">team@splitsave.community</a> and we&apos;ll help you out.
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- replace the mobile landing and app experience with a testing screen when accessed from non-PWA mobile clients
- add a reusable MobileTestingScreen component that communicates the temporary maintenance state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da762640f88323b10e7fcc73a6343d