### PR TITLE
Re-enable mobile site behind feature flag

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,9 @@ export default function Home() {
   const [isStandalonePWA, setIsStandalonePWA] = useState(false)
   const [hasAuthToken, setHasAuthToken] = useState<boolean | null>(null)
   const { isMobile, isSmallScreen, isClient } = useMobileDetection()
-  const shouldShowMobileTesting = isClient && (isMobile || isSmallScreen) && !isStandalonePWA
+  const isMobileTestingMode = process.env.NEXT_PUBLIC_MOBILE_TESTING_MODE === 'true'
+  const shouldShowMobileTesting =
+    isMobileTestingMode && isClient && (isMobile || isSmallScreen) && !isStandalonePWA
 
   const checkStoredAuthToken = useCallback(() => {
     if (typeof window === 'undefined') {

--- a/env.example
+++ b/env.example
@@ -6,3 +6,6 @@ SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 # App Configuration
 NEXTAUTH_SECRET=your-nextauth-secret
 NEXTAUTH_URL=http://localhost:3000
+
+# Mobile testing flag (set to "true" to temporarily disable the mobile web experience)
+NEXT_PUBLIC_MOBILE_TESTING_MODE=false


### PR DESCRIPTION
## Summary
- gate the mobile maintenance screen behind a NEXT_PUBLIC_MOBILE_TESTING_MODE flag so the mobile experience loads again by default
- document the new mobile testing flag in the example environment configuration for future toggles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da8a0836ec83239d86017b5d68d61e