### PR TITLE
Add query-controlled mobile testing and debug panel

### DIFF
--- a/components/mobile/MobileTestingScreen.tsx
+++ b/components/mobile/MobileTestingScreen.tsx
@@ -1,10 +1,38 @@
 'use client'
 
-interface MobileTestingScreenProps {
-  variant?: 'default' | 'loading'
+import { useMemo, useState } from 'react'
+
+interface MobileTestingDebugInfo {
+  flags: {
+    envMobileTestingFlag: boolean
+    forceMobileTesting: boolean
+    mobileDebug: boolean
+  }
+  device: {
+    isMobile: boolean
+    isSmallScreen: boolean
+    isClient: boolean
+    isStandalonePWA: boolean
+  }
+  auth: {
+    hasAuthToken: boolean | null
+    loading: boolean
+    hasUser: boolean
+    userEmail: string | null
+  }
 }
 
-export function MobileTestingScreen({ variant = 'default' }: MobileTestingScreenProps) {
+interface MobileTestingScreenProps {
+  variant?: 'default' | 'loading'
+  debugInfo?: MobileTestingDebugInfo
+  showDebugPanel?: boolean
+}
+
+export function MobileTestingScreen({
+  variant = 'default',
+  debugInfo,
+  showDebugPanel = false
+}: MobileTestingScreenProps) {
   const headline =
     variant === 'loading'
       ? 'Mobile experience under maintenance'
@@ -14,6 +42,49 @@ export function MobileTestingScreen({ variant = 'default' }: MobileTestingScreen
     variant === 'loading'
       ? 'We’re currently diagnosing mobile loading issues. Please check back soon or use SplitSave on desktop.'
       : 'The mobile website is temporarily disabled while we debug loading issues. SplitSave is still available on desktop.'
+
+  const [isDebugExpanded, setIsDebugExpanded] = useState(showDebugPanel)
+  const shouldShowDebugPanel = Boolean(debugInfo && (showDebugPanel || debugInfo.flags.mobileDebug))
+
+  const debugItems = useMemo(() => {
+    if (!debugInfo) return []
+
+    return [
+      {
+        title: 'Feature flags',
+        entries: [
+          ['Env mobile testing flag', debugInfo.flags.envMobileTestingFlag ? 'enabled' : 'disabled'],
+          ['forceMobileTesting query', debugInfo.flags.forceMobileTesting ? 'enabled' : 'disabled'],
+          ['mobileDebug query', debugInfo.flags.mobileDebug ? 'enabled' : 'disabled']
+        ]
+      },
+      {
+        title: 'Device detection',
+        entries: [
+          ['Detected mobile', debugInfo.device.isMobile ? 'yes' : 'no'],
+          ['Small screen', debugInfo.device.isSmallScreen ? 'yes' : 'no'],
+          ['Client side', debugInfo.device.isClient ? 'yes' : 'no'],
+          ['Standalone PWA', debugInfo.device.isStandalonePWA ? 'yes' : 'no']
+        ]
+      },
+      {
+        title: 'Auth status',
+        entries: [
+          ['Auth loading', debugInfo.auth.loading ? 'yes' : 'no'],
+          [
+            'Stored auth token',
+            debugInfo.auth.hasAuthToken === null
+              ? 'unknown'
+              : debugInfo.auth.hasAuthToken
+              ? 'present'
+              : 'missing'
+          ],
+          ['Has user', debugInfo.auth.hasUser ? 'yes' : 'no'],
+          ['User email', debugInfo.auth.userEmail ?? 'n/a']
+        ]
+      }
+    ]
+  }, [debugInfo])
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-purple-50 via-white to-white dark:from-gray-950 dark:via-gray-900 dark:to-gray-900 flex items-center justify-center px-6 py-16">
@@ -31,6 +102,42 @@ export function MobileTestingScreen({ variant = 'default' }: MobileTestingScreen
         <p className="mt-6 text-xs text-gray-500 dark:text-gray-400">
           Need access urgently? Email <a className="font-semibold text-purple-600 hover:text-purple-500" href="mailto:team@splitsave.community">team@splitsave.community</a> and we&apos;ll help you out.
         </p>
+        {shouldShowDebugPanel && debugItems.length > 0 && (
+          <div className="mt-8 text-left text-xs text-gray-600 dark:text-gray-300">
+            <button
+              type="button"
+              onClick={() => setIsDebugExpanded((prev) => !prev)}
+              className="flex w-full items-center justify-between rounded-lg border border-purple-200/60 bg-purple-50/60 px-4 py-2 font-semibold text-purple-700 transition hover:bg-purple-100 dark:border-purple-800/60 dark:bg-purple-950/30 dark:text-purple-200 dark:hover:bg-purple-900/40"
+            >
+              <span>Debug details</span>
+              <span>{isDebugExpanded ? '−' : '+'}</span>
+            </button>
+            {isDebugExpanded && (
+              <div className="mt-3 space-y-4 rounded-lg border border-purple-100/60 bg-white/70 p-4 text-gray-700 shadow-sm dark:border-purple-900/50 dark:bg-gray-900/70 dark:text-gray-200">
+                {debugItems.map((section) => (
+                  <div key={section.title}>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-purple-600 dark:text-purple-300">
+                      {section.title}
+                    </p>
+                    <dl className="mt-2 space-y-1">
+                      {section.entries.map(([label, value]) => (
+                        <div key={label} className="flex justify-between gap-4">
+                          <dt className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                            {label}
+                          </dt>
+                          <dd className="text-sm font-medium text-gray-900 dark:text-gray-100">{value}</dd>
+                        </div>
+                      ))}
+                    </dl>
+                  </div>
+                ))}
+                <p className="mt-3 text-[11px] text-gray-500 dark:text-gray-400">
+                  Tip: append <code className="rounded bg-gray-100 px-1 py-0.5 text-[10px] dark:bg-gray-800">?forceMobileTesting=true&amp;mobileDebug=true</code> to the URL to enable this panel on any device.
+                </p>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/env.example
+++ b/env.example
@@ -6,3 +6,7 @@ SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 # App Configuration
 NEXTAUTH_SECRET=your-nextauth-secret
 NEXTAUTH_URL=http://localhost:3000
+
+# Mobile testing flag (set to "true" to temporarily disable the mobile web experience)
+# You can also append ?forceMobileTesting=true to the app URL for a one-off debug session
+NEXT_PUBLIC_MOBILE_TESTING_MODE=false


### PR DESCRIPTION
## Summary
- allow the mobile maintenance screen to be forced via `?forceMobileTesting=true` and expose a debug toggle with `?mobileDebug=true`
- surface structured device, auth, and flag details inside the mobile maintenance screen to aid remote debugging
- document the new query string override alongside the existing mobile testing environment flag

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da8a0836ec83239d86017b5d68d61e