### PR TITLE
Fix mobile login crash caused by custom chunk settings

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -107,53 +107,18 @@ const nextConfig = {
 
   // Webpack optimizations
   webpack: (config, { dev, isServer }) => {
-    // Production optimizations
-    if (!dev && !isServer) {
-      // Enable tree shaking
-      config.optimization.usedExports = true
-      config.optimization.sideEffects = false
-      
-      // Enhanced code splitting
-      config.optimization.splitChunks = {
-        chunks: 'all',
-        cacheGroups: {
-          vendor: {
-            test: /[\\/]node_modules[\\/]/,
-            name: 'vendors',
-            chunks: 'all',
-            priority: 10,
-            enforce: true,
-          },
-          common: {
-            name: 'common',
-            minChunks: 2,
-            chunks: 'all',
-            enforce: true,
-            priority: 5,
-          },
-          // Separate large libraries
-          supabase: {
-            test: /[\\/]node_modules[\\/]@supabase[\\/]/,
-            name: 'supabase',
-            chunks: 'all',
-            priority: 20,
-          },
-        },
-      }
-      
-      // Bundle analyzer (optional)
-      if (process.env.ANALYZE === 'true') {
-        const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
-        config.plugins.push(
-          new BundleAnalyzerPlugin({
-            analyzerMode: 'static',
-            openAnalyzer: false,
-            reportFilename: 'bundle-analysis.html',
-            generateStatsFile: true,
-            statsFilename: 'bundle-stats.json',
-          })
-        )
-      }
+    // Bundle analyzer (optional)
+    if (!dev && !isServer && process.env.ANALYZE === 'true') {
+      const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
+      config.plugins.push(
+        new BundleAnalyzerPlugin({
+          analyzerMode: 'static',
+          openAnalyzer: false,
+          reportFilename: 'bundle-analysis.html',
+          generateStatsFile: true,
+          statsFilename: 'bundle-stats.json',
+        })
+      )
     }
 
     // Optimize images


### PR DESCRIPTION
## Summary
- remove the custom client-side splitChunks/sideEffects tweaks so Next.js no longer emits CSS assets as `<script>` tags, fixing the mobile login crash that appeared once the browser blocked those requests under `X-Content-Type-Options: nosniff`
- keep the bundle-analyzer hook available when explicitly enabled while otherwise deferring bundling decisions back to Next.js defaults

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2391eb7888323ba652edbbcb97ce9