### PR TITLE
Timeout Supabase session check to prevent mobile loading freeze

### DIFF
--- a/components/auth/SimpleAuthProvider.tsx
+++ b/components/auth/SimpleAuthProvider.tsx
@@ -18,14 +18,25 @@ export function SimpleAuthProvider({ children }: { children: React.ReactNode }) 
   const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(true)
 
+  const getSessionWithTimeout = async (timeoutMs: number) => {
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error(`Session check timed out after ${timeoutMs}ms`)), timeoutMs)
+    })
+
+    return Promise.race([supabase.auth.getSession(), timeoutPromise])
+  }
+
   useEffect(() => {
     let mounted = true
     let failsafeTimer: ReturnType<typeof setTimeout> | null = null
 
-    // Simple session check with longer timeout for mobile networks
+    // Simple session check with timeout so mobile doesn't hang indefinitely
     const checkSession = async () => {
       try {
         setLoading(true)
+
+        const isMobile = typeof window !== 'undefined' && window.matchMedia('(max-width: 768px)').matches
+        const sessionTimeoutMs = isMobile ? 6000 : 4000
 
         // Longer failsafe for slow mobile networks (10 seconds)
         failsafeTimer = setTimeout(() => {
@@ -35,8 +46,7 @@ export function SimpleAuthProvider({ children }: { children: React.ReactNode }) 
           }
         }, 10000)
 
-        // Direct session check without race condition - wait for actual result
-        const { data: { session }, error } = await supabase.auth.getSession()
+        const { data: { session }, error } = await getSessionWithTimeout(sessionTimeoutMs)
 
         if (error) {
           console.log('Auth check error:', error)


### PR DESCRIPTION
### Motivation
- Mobile users reported the app freezing on the loading screen when the Supabase session check stalled, so the auth bootstrap needs a guaranteed timeout to allow the app to proceed.

### Description
- Added a `getSessionWithTimeout` helper that races `supabase.auth.getSession()` against a timeout to avoid indefinite waits in `components/auth/SimpleAuthProvider.tsx`.
- Use device-aware timeouts (mobile: `6000ms`, desktop: `4000ms`) when calling the session helper so slow mobile networks get more time without blocking forever.
- Kept the existing longer failsafe timer and cleanup logic so loading is still cleared reliably and timers/subscriptions are cancelled on unmount.

### Testing
- Ran `npm run lint -- --file components/auth/SimpleAuthProvider.tsx`, which completed without ESLint errors.
- Ran `npm run type-check` which failed due to pre-existing TypeScript errors in `__tests__/pwa/MobilePWA.test.tsx` (readonly assignment issues) that are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a72911911c8323a5f8286a84dfd5f9)