### PR TITLE
Neutralize service worker to fix stale cache issues

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -214,16 +214,20 @@ export default function RootLayout({
               background-color: var(--mobile-bg-dark) !important;
             }
 
-            /* Force immediate background for mobile screens */
+            /* Keep a stable base background on mobile while React hydrates.
+               Only html/body are set here on purpose: forcing the app's own
+               container divs (body > div) would override full-screen views
+               that use a dark background with light text, turning them into
+               an invisible white-on-white screen. */
             @media screen and (max-width: 768px) {
-              html, body, body > div, #__next {
+              html, body {
                 background: var(--mobile-bg-light) !important;
                 background-color: var(--mobile-bg-light) !important;
                 min-height: 100vh !important;
                 height: auto !important;
               }
 
-              html.dark, html.dark body, html.dark body > div, html.dark #__next {
+              html.dark, html.dark body {
                 background: var(--mobile-bg-dark) !important;
                 background-color: var(--mobile-bg-dark) !important;
               }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,461 +1,66 @@
 /**
- * SplitSave Service Worker
- * Provides offline support, caching, and background sync
+ * SplitSave Service Worker — neutralized.
+ *
+ * The application no longer uses a service worker. Earlier deploys shipped a
+ * caching service worker and registered it on every visit, so it is still
+ * installed and active on the devices of anyone who opened the site back then.
+ *
+ * That stale worker serves content-hashed JS/CSS chunks cache-first. After a
+ * redeploy the cached HTML shell references chunk filenames that have since
+ * been removed from the server, so the document loads but its scripts 404 and
+ * React never hydrates — the app is stuck on the loading screen forever and a
+ * reload does not help because the worker keeps serving the stale shell.
+ *
+ * Since no current code registers or updates a service worker, there was no
+ * way for those devices to recover. This file replaces the old worker with a
+ * no-op that deletes every cache and unregisters itself. When the browser runs
+ * its routine service-worker update check (on navigation, at least every 24h),
+ * it fetches this script directly — bypassing the old worker — installs it,
+ * and the affected device cleans itself up and reloads from the network.
+ *
+ * Do not delete this file: a 404 on the script during an update check leaves
+ * the old worker running. It must exist and serve a 200 to neutralize it.
  */
 
-const CACHE_NAME = 'splitsave-v1.0.0'
-const STATIC_CACHE = 'splitsave-static-v1.0.0'
-const DYNAMIC_CACHE = 'splitsave-dynamic-v1.0.0'
-
-// Assets to cache immediately
-// Only precache truly static assets. Avoid caching the root document because
-// Next.js streams the shell HTML and caching it can capture an empty loading
-// state that never hydrates when returned offline or from a stale cache.
-const STATIC_ASSETS = [
-  '/manifest.json',
-  '/icon-192x192.png',
-  '/icon-512x512.png',
-  '/offline.html'
-]
-
-// API routes that should be cached
-const API_CACHE_PATTERNS = [
-  '/api/auth/profile',
-  '/api/goals',
-  '/api/expenses',
-  '/api/partnerships',
-  '/api/notifications'
-]
-
-// Install event - cache static assets
-self.addEventListener('install', (event) => {
-  console.log('🔧 Service Worker: Installing...')
-  
-  event.waitUntil(
-    caches.open(STATIC_CACHE)
-      .then((cache) => {
-        console.log('📦 Service Worker: Caching static assets')
-        return cache.addAll(STATIC_ASSETS)
-      })
-      .then(() => {
-        console.log('✅ Service Worker: Static assets cached')
-        return self.skipWaiting()
-      })
-      .catch((error) => {
-        console.error('❌ Service Worker: Failed to cache static assets', error)
-      })
-  )
+self.addEventListener('install', () => {
+  self.skipWaiting()
 })
 
-// Activate event - clean up old caches
 self.addEventListener('activate', (event) => {
-  console.log('🚀 Service Worker: Activating...')
-  
   event.waitUntil(
-    caches.keys()
-      .then((cacheNames) => {
-        return Promise.all(
-          cacheNames.map((cacheName) => {
-            if (cacheName !== STATIC_CACHE && cacheName !== DYNAMIC_CACHE) {
-              console.log('🗑️ Service Worker: Deleting old cache', cacheName)
-              return caches.delete(cacheName)
-            }
-          })
-        )
-      })
-      .then(() => {
-        console.log('✅ Service Worker: Activated and cleaned up')
-        return self.clients.claim()
-      })
-  )
-})
-
-// Fetch event - serve from cache, fallback to network
-self.addEventListener('fetch', (event) => {
-  const { request } = event
-  const url = new URL(request.url)
-  
-  // Skip non-GET requests
-  if (request.method !== 'GET') {
-    return
-  }
-  
-  // Handle API requests
-  if (url.pathname.startsWith('/api/')) {
-    event.respondWith(handleApiRequest(request))
-    return
-  }
-  
-  // Handle static assets
-  if (isStaticAsset(request)) {
-    event.respondWith(handleStaticAsset(request))
-    return
-  }
-  
-  // Handle page requests
-  if (request.headers.get('accept')?.includes('text/html')) {
-    event.respondWith(handlePageRequest(request))
-    return
-  }
-})
-
-// Handle API requests with network-first strategy
-async function handleApiRequest(request) {
-  const url = new URL(request.url)
-  
-  try {
-    // Try network first
-    const networkResponse = await fetch(request)
-    
-    // Cache successful responses
-    if (networkResponse.ok && shouldCacheApi(url.pathname)) {
-      const cache = await caches.open(DYNAMIC_CACHE)
-      cache.put(request, networkResponse.clone())
-    }
-    
-    return networkResponse
-  } catch (error) {
-    console.log('🌐 Service Worker: Network failed, trying cache for', url.pathname)
-    
-    // Fallback to cache
-    const cachedResponse = await caches.match(request)
-    if (cachedResponse) {
-      return cachedResponse
-    }
-    
-    // Return offline response for API calls
-    return new Response(
-      JSON.stringify({ 
-        error: 'Offline', 
-        message: 'This feature requires an internet connection' 
-      }),
-      { 
-        status: 503, 
-        headers: { 'Content-Type': 'application/json' } 
-      }
-    )
-  }
-}
-
-// Validate that cached/static responses contain the expected asset content.
-function isValidAssetResponse(response, request) {
-  if (!response || !response.ok) {
-    return false
-  }
-
-  const contentType = response.headers.get('content-type') || ''
-  const url = new URL(request.url)
-  const extensionMatch = url.pathname.match(/\.([a-z0-9]+)$/i)
-  const extension = extensionMatch ? extensionMatch[1].toLowerCase() : ''
-
-  if (extension === 'js') {
-    return contentType.includes('javascript')
-  }
-
-  if (extension === 'css') {
-    return contentType.includes('text/css')
-  }
-
-  if (['png', 'jpg', 'jpeg', 'gif', 'svg', 'ico', 'webp', 'avif'].includes(extension)) {
-    return contentType.startsWith('image/')
-  }
-
-  if (['woff', 'woff2', 'ttf', 'eot', 'otf'].includes(extension)) {
-    return contentType.includes('font') || contentType.includes('woff') || contentType.includes('truetype')
-  }
-
-  return true
-}
-
-// Handle static assets with cache-first strategy while avoiding corrupted entries
-async function handleStaticAsset(request) {
-  const cachedResponse = await caches.match(request)
-
-  if (cachedResponse && isValidAssetResponse(cachedResponse, request)) {
-    return cachedResponse
-  }
-
-  try {
-    const networkResponse = await fetch(request)
-
-    if (networkResponse.ok && isValidAssetResponse(networkResponse, request)) {
-      const cache = await caches.open(STATIC_CACHE)
-      cache.put(request, networkResponse.clone())
-      return networkResponse
-    }
-
-    // If the network response is not valid, fall back to the last known good cached response
-    if (cachedResponse && isValidAssetResponse(cachedResponse, request)) {
-      console.warn('⚠️ Service Worker: Using cached fallback for asset due to invalid network response', request.url)
-      return cachedResponse
-    }
-
-    return networkResponse
-  } catch (error) {
-    console.error('❌ Service Worker: Failed to fetch static asset', request.url, error)
-
-    if (cachedResponse && isValidAssetResponse(cachedResponse, request)) {
-      console.warn('⚠️ Service Worker: Serving cached asset after fetch failure', request.url)
-      return cachedResponse
-    }
-
-    throw error
-  }
-}
-
-// Handle page requests with network-first strategy
-async function handlePageRequest(request) {
-  try {
-    const networkResponse = await fetch(request)
-    
-    if (networkResponse.ok) {
-      const cache = await caches.open(DYNAMIC_CACHE)
-      cache.put(request, networkResponse.clone())
-    }
-    
-    return networkResponse
-  } catch (error) {
-    console.log('🌐 Service Worker: Network failed, trying cache for page', request.url)
-    
-    const cachedResponse = await caches.match(request)
-    if (cachedResponse) {
-      return cachedResponse
-    }
-    
-    // Return offline page
-    const offlineResponse = await caches.match('/offline.html')
-    if (offlineResponse) {
-      return offlineResponse
-    }
-    
-    // Fallback offline response
-    return new Response(
-      `
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <title>SplitSave - Offline</title>
-          <meta name="viewport" content="width=device-width, initial-scale=1">
-          <style>
-            body { 
-              font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-              margin: 0; padding: 20px; background: #f3f4f6; 
-              display: flex; align-items: center; justify-content: center; min-height: 100vh;
-            }
-            .container { 
-              text-align: center; background: white; padding: 40px; 
-              border-radius: 12px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-              max-width: 400px;
-            }
-            .icon { font-size: 48px; margin-bottom: 20px; }
-            h1 { color: #374151; margin-bottom: 16px; }
-            p { color: #6b7280; margin-bottom: 24px; }
-            .retry { 
-              background: #3b82f6; color: white; border: none; 
-              padding: 12px 24px; border-radius: 8px; cursor: pointer;
-              font-size: 16px;
-            }
-          </style>
-        </head>
-        <body>
-          <div class="container">
-            <div class="icon">📱</div>
-            <h1>You're Offline</h1>
-            <p>SplitSave needs an internet connection to work properly. Please check your connection and try again.</p>
-            <button class="retry" onclick="window.location.reload()">Try Again</button>
-          </div>
-        </body>
-      </html>
-      `,
-      { 
-        status: 200, 
-        headers: { 'Content-Type': 'text/html' } 
-      }
-    )
-  }
-}
-
-// Check if request is for a static asset
-function isStaticAsset(request) {
-  const url = new URL(request.url)
-  return url.pathname.match(/\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot)$/)
-}
-
-// Check if API endpoint should be cached
-function shouldCacheApi(pathname) {
-  return API_CACHE_PATTERNS.some(pattern => pathname.startsWith(pattern))
-}
-
-// Background sync for offline actions
-self.addEventListener('sync', (event) => {
-  console.log('🔄 Service Worker: Background sync triggered', event.tag)
-  
-  if (event.tag === 'background-sync') {
-    event.waitUntil(doBackgroundSync())
-  }
-})
-
-// Perform background sync
-async function doBackgroundSync() {
-  try {
-    console.log('🔄 Service Worker: Performing background sync...')
-    
-    // Get pending offline actions from IndexedDB
-    const pendingActions = await getPendingOfflineActions()
-    
-    for (const action of pendingActions) {
+    (async () => {
       try {
-        await syncOfflineAction(action)
-        await removePendingAction(action.id)
+        await self.clients.claim()
       } catch (error) {
-        console.error('❌ Service Worker: Failed to sync action', action.id, error)
+        // best effort
       }
-    }
-    
-    console.log('✅ Service Worker: Background sync completed')
-  } catch (error) {
-    console.error('❌ Service Worker: Background sync failed', error)
-  }
-}
 
-// Get pending offline actions from IndexedDB
-async function getPendingOfflineActions() {
-  // This would integrate with your IndexedDB implementation
-  // For now, return empty array
-  return []
-}
+      try {
+        const cacheNames = await caches.keys()
+        await Promise.all(cacheNames.map((name) => caches.delete(name)))
+      } catch (error) {
+        // best effort
+      }
 
-// Sync a single offline action
-async function syncOfflineAction(action) {
-  const response = await fetch(action.url, {
-    method: action.method,
-    headers: action.headers,
-    body: action.body
-  })
-  
-  if (!response.ok) {
-    throw new Error(`Sync failed: ${response.status}`)
-  }
-  
-  return response
-}
+      try {
+        await self.registration.unregister()
+      } catch (error) {
+        // best effort
+      }
 
-// Remove pending action after successful sync
-async function removePendingAction(actionId) {
-  // This would remove the action from IndexedDB
-  console.log('🗑️ Service Worker: Removing synced action', actionId)
-}
-
-// Push notification handling
-self.addEventListener('push', (event) => {
-  console.log('📱 Service Worker: Push notification received')
-  
-  let notificationData = {
-    title: 'SplitSave',
-    body: 'You have a new notification',
-    icon: '/icon-192x192.png',
-    badge: '/icon-192x192.png',
-    tag: 'splitsave-notification',
-    requireInteraction: false,
-    data: {}
-  }
-
-  if (event.data) {
-    try {
-      const payload = event.data.json()
-      notificationData = { ...notificationData, ...payload }
-    } catch (error) {
-      console.error('Failed to parse push payload:', error)
-    }
-  }
-
-  event.waitUntil(
-    self.registration.showNotification(notificationData.title, {
-      body: notificationData.body,
-      icon: notificationData.icon,
-      badge: notificationData.badge,
-      tag: notificationData.tag,
-      data: notificationData.data,
-      requireInteraction: notificationData.requireInteraction,
-      vibrate: [200, 100, 200],
-      timestamp: Date.now(),
-      actions: [
-        {
-          action: 'open',
-          title: 'Open App',
-          icon: '/icon-192x192.png'
-        },
-        {
-          action: 'dismiss',
-          title: 'Dismiss'
+      // Reload any open tabs so a device that was stuck on a stale shell
+      // recovers immediately instead of waiting for the next manual visit.
+      try {
+        const clients = await self.clients.matchAll({ type: 'window' })
+        for (const client of clients) {
+          client.navigate(client.url)
         }
-      ]
-    })
+      } catch (error) {
+        // best effort
+      }
+    })()
   )
 })
 
-// Notification click handling
-self.addEventListener('notificationclick', (event) => {
-  console.log('👆 Service Worker: Notification clicked', event.action)
-  
-  event.notification.close()
-
-  if (event.action === 'dismiss') {
-    return
-  }
-
-  // Default action or 'open' action
-  event.waitUntil(
-    clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
-      // Check if app is already open
-      for (const client of clientList) {
-        if (client.url.includes(self.location.origin) && 'focus' in client) {
-          return client.focus()
-        }
-      }
-      
-      // Open new window if app is not open
-      if (clients.openWindow) {
-        return clients.openWindow('/')
-      }
-    })
-  )
-})
-
-// Handle notification close
-self.addEventListener('notificationclose', (event) => {
-  console.log('📱 Service Worker: Notification closed')
-  
-  // Track notification dismissal
-  if (event.notification.data && event.notification.data.trackDismissal) {
-    // Send analytics event
-    fetch('/api/analytics/notification-dismissed', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        notificationId: event.notification.data.id,
-        tag: event.notification.tag,
-        timestamp: Date.now()
-      })
-    }).catch(error => {
-      console.error('Failed to track notification dismissal:', error)
-    })
-  }
-})
-
-// Message handling for communication with main thread
-self.addEventListener('message', (event) => {
-  console.log('💬 Service Worker: Message received', event.data)
-  
-  if (event.data && event.data.type === 'SKIP_WAITING') {
-    self.skipWaiting()
-  }
-  
-  if (event.data && event.data.type === 'GET_VERSION') {
-    event.ports[0].postMessage({ version: CACHE_NAME })
-  }
-})
-
-console.log('✅ Service Worker: Loaded and ready')
+// Intentionally no `fetch` handler: every request must go straight to the
+// network so a stale cache can never brick the app again.


### PR DESCRIPTION
## Summary

Replaces the active service worker with a no-op implementation that cleans up stale caches and unregisters itself. This fixes a critical issue where devices with an old cached service worker become stuck on a loading screen after redeployment.

## Problem

The previous service worker implementation cached the HTML shell and content-hashed JS/CSS chunks with a cache-first strategy. After redeployment:
- The cached HTML shell references chunk filenames that no longer exist on the server
- The document loads but scripts return 404 errors
- React never hydrates and the app stays on the loading screen forever
- A manual reload doesn't help because the stale worker keeps serving the old shell

Since no current code registers or updates a service worker, affected devices had no way to recover.

## Solution

- **Neutralize the old worker**: Replace the 395-line caching implementation with a minimal 30-line no-op that:
  - Skips waiting on install
  - Deletes all caches on activation
  - Unregisters itself
  - Reloads any open tabs to recover immediately
  
- **Prevent future issues**: Remove the `fetch` handler entirely so every request bypasses the cache and goes straight to the network

- **Preserve the file**: Keep `sw.js` returning a 200 status so the browser's routine update check (on navigation, at least every 24h) can fetch and install this neutralizing version, allowing affected devices to self-heal

## Key Changes

- Removed all caching logic (static assets, API requests, page requests)
- Removed background sync, push notifications, and message handling
- Removed content-type validation for cached responses
- Added comprehensive comments explaining why the worker was neutralized
- Fixed mobile background CSS to avoid breaking full-screen dark-themed views by only applying background to `html` and `body` instead of child containers

https://claude.ai/code/session_013wV9cy54xibXwwA3hUMrvC