### PR TITLE
Fix loading screen stuck forever: reach kill-switch SW + self-heal chunk failures

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import { ThemeProvider } from '@/components/ui/ThemeProvider'
 import { MobilePWA } from '@/components/pwa/MobilePWA'
+import { RuntimeErrorRecovery } from '@/components/pwa/RuntimeErrorRecovery'
 // Debug components removed to prevent hydration issues
 // import { MobileDebugOverlay } from '@/components/mobile/MobileDebugOverlay'
 // import { PWAAuthDebug } from '@/components/debug/PWAAuthDebug'
@@ -253,6 +254,9 @@ export default function RootLayout({
         }} />
       </head>
       <body className="antialiased">
+        {/* Recovers the app if a stale/cached chunk fails to load instead of
+            leaving the user stuck on a loading screen forever. */}
+        <RuntimeErrorRecovery />
         {/* EMERGENCY TEST REMOVED - Using direct mobile bypass instead */}
 
         {/* iPhone Safari emergency fallback - shows if React fails to load */}

--- a/next.config.js
+++ b/next.config.js
@@ -102,6 +102,18 @@ const nextConfig = {
           },
         ],
       },
+      // The service worker script must never be cached, otherwise browsers
+      // (iOS Safari in particular) keep an old worker that can serve stale,
+      // content-hashed chunks and brick the app on the loading screen.
+      {
+        source: '/sw.js',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'no-cache, no-store, must-revalidate',
+          },
+        ],
+      },
     ]
   },
 

--- a/vercel.json
+++ b/vercel.json
@@ -47,6 +47,15 @@
           "value": "public, max-age=31536000, immutable"
         }
       ]
+    },
+    {
+      "source": "/sw.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        }
+      ]
     }
   ],
   "rewrites": [


### PR DESCRIPTION
## Summary

Follow-up to #60. The kill-switch service worker from #60 could not reach affected devices, so the loading screen is still stuck for returning mobile users.

- **Stop caching `/sw.js`.** `vercel.json` served every `.js` (including the service worker script) as `public, max-age=31536000, immutable`. iOS Safari honored that and never re-fetched `/sw.js`, so the old caching worker from earlier deploys stayed installed and kept serving stale, content-hashed chunks that 404 after a redeploy — the document loads but its scripts fail, React never hydrates, and the loading screen freezes forever. Added a `/sw.js` `no-cache, no-store, must-revalidate` override in both `vercel.json` and `next.config.js` so the worker script always revalidates and the #60 kill-switch can actually take effect.
- **Mount `RuntimeErrorRecovery`.** The app already shipped a component purpose-built to catch `ChunkLoadError`, clear the service worker/caches, and reload — but it was never rendered anywhere. Wired it into the root layout so a stale-chunk failure now self-heals instead of leaving the user stuck on the loading screen.

## Test plan

- [x] `npm run build` compiles successfully
- [x] Regression: mobile/desktop pages still render normally with `RuntimeErrorRecovery` mounted
- [x] Simulated a `ChunkLoadError` in a headless browser → seeded stale cache is cleared, page auto-reloads, app renders correctly
- [x] `vercel.json` valid JSON; `next.config.js` loads; `/sw.js` syntax-checked
- [ ] After deploy: confirm `/sw.js` responds with `Cache-Control: no-cache` and a previously-stuck device recovers on next visit

https://claude.ai/code/session_013wV9cy54xibXwwA3hUMrvC

---
_Generated by [Claude Code](https://claude.ai/code/session_013wV9cy54xibXwwA3hUMrvC)_