### PR TITLE
Fix iOS Safari blank screen: guard Notification global access

### DIFF
--- a/components/notifications/SmartNotifications.tsx
+++ b/components/notifications/SmartNotifications.tsx
@@ -237,7 +237,7 @@ export function SmartNotifications() {
       </div>
 
       {/* Notification Permission */}
-      {Notification.permission !== 'granted' && (
+      {typeof window !== 'undefined' && 'Notification' in window && Notification.permission !== 'granted' && (
         <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-6">
           <div className="flex items-start space-x-3">
             <span className="text-2xl">🔔</span>

--- a/lib/push-notifications.ts
+++ b/lib/push-notifications.ts
@@ -26,8 +26,12 @@ class PushNotificationManager {
   private permission: NotificationPermission = 'default'
 
   constructor() {
-    this.isSupported = typeof window !== 'undefined' && 'Notification' in window && 'serviceWorker' in navigator
-    this.permission = typeof window !== 'undefined' ? Notification.permission : 'default'
+    const hasNotificationApi = typeof window !== 'undefined' && 'Notification' in window
+    this.isSupported = hasNotificationApi && 'serviceWorker' in navigator
+    // iOS Safari doesn't expose Notification as a global at all (not just unsupported);
+    // accessing it without an `in window` guard throws ReferenceError and crashes the
+    // bundle at module load via the singleton below.
+    this.permission = hasNotificationApi ? Notification.permission : 'default'
   }
 
   /**


### PR DESCRIPTION
## Summary

**The actual fix for the blank-screen-on-iOS-Safari bug.** The `?diag=1` overlay merged in #63 captured the smoking gun on a real iPhone:

```
ReferenceError: Can't find variable: Notification
  @ /_next/static/chunks/fd9d1056-...js
```

`lib/push-notifications.ts` exports a top-level singleton (`new PushNotificationManager()`). Its constructor read `Notification.permission` after only checking `typeof window`, not `'Notification' in window`. iOS Safari **does not expose `Notification` as a global at all** — referencing it throws `ReferenceError`, which fires at module-load time in the mobile-page bundle's import graph, killing React hydration before it can mount anything. That's why the device showed a blank dark screen with no visible error.

Chromium exposes `Notification` everywhere, which is why every headless test passed and the bug only manifested on real WebKit.

### Changes

- `lib/push-notifications.ts` — constructor checks `'Notification' in window` before reading `Notification.permission`. Falls back to `'default'`.
- `components/notifications/SmartNotifications.tsx` — render-time read of `Notification.permission` (in JSX) gets the same guard.

Other accesses in `lib/notification-system.ts` and `SmartNotifications.tsx` were already inside `'Notification' in window` guards and are unchanged.

## Test plan

- [x] `npm run build` compiles successfully
- [x] Simulated real iOS Safari (delete `window.Notification` so `'Notification' in window === false`): **before fix** body was empty + `PAGEERROR: Can't find variable: Notification`; **after fix** landing page renders, zero errors
- [x] Regression: with `Notification` present (Chromium default), landing page renders identically with zero errors
- [ ] After deploy: open `https://split-save.vercel.app/` on the affected iPhone (no `?diag=1` needed) and confirm the app loads

https://claude.ai/code/session_013wV9cy54xibXwwA3hUMrvC

---
_Generated by [Claude Code](https://claude.ai/code/session_013wV9cy54xibXwwA3hUMrvC)_