### PR TITLE
Wire up mobile bottom nav + remove diag overlay

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -141,14 +141,6 @@ export default function RootLayout({
             __html: `(function(){try{if(!('serviceWorker' in navigator))return;navigator.serviceWorker.getRegistrations().then(function(regs){if(!regs||!regs.length)return;Promise.all(regs.map(function(r){return r.unregister().catch(function(){})})).then(function(){if(window.caches&&caches.keys){return caches.keys().then(function(ks){return Promise.all(ks.map(function(k){return caches.delete(k)}))}).catch(function(){})}}).then(function(){try{if(!sessionStorage.getItem('ss-sw-reset')){sessionStorage.setItem('ss-sw-reset','1');location.reload()}}catch(e){location.reload()}})}).catch(function(){})}catch(e){}})();`
           }}
         />
-        {/* On-page error overlay (only when URL has ?diag=1). Surfaces any
-            error or unhandled rejection visually so a device that fails to
-            hydrate can be diagnosed without a Mac+USB Web Inspector. */}
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `(function(){try{var on=/[?&]diag=1/.test(location.search);var off=/[?&]diag=0/.test(location.search);try{if(on)localStorage.setItem('ss-diag','1');if(off)localStorage.removeItem('ss-diag')}catch(e){}var enabled=on;try{if(!enabled&&localStorage.getItem('ss-diag')==='1')enabled=true}catch(e){}if(!enabled)return;var n=0;var show=function(label,text){n++;var d=document.createElement('div');d.style.cssText='position:fixed;left:0;right:0;z-index:2147483647;background:#fef2f2;color:#7f1d1d;padding:10px 12px;font:12px ui-monospace,Menlo,Consolas,monospace;white-space:pre-wrap;word-break:break-word;border-bottom:3px solid #dc2626;max-height:50vh;overflow:auto;top:'+((n-1)*8)+'px;';d.textContent='['+label+' #'+n+'] '+text;var attach=function(){if(document.body){document.body.appendChild(d)}else{setTimeout(attach,30)}};attach()};window.addEventListener('error',function(e){show('ERROR',(e.message||'')+' @ '+(e.filename||'')+':'+(e.lineno||'')+':'+(e.colno||'')+'\\n'+((e.error&&e.error.stack)||'').slice(0,900))});window.addEventListener('unhandledrejection',function(e){var r=e&&e.reason;show('PROMISE',(r&&r.message?r.message:String(r))+'\\n'+((r&&r.stack)||'').slice(0,900))});var stamp=document.createElement('div');stamp.style.cssText='position:fixed;bottom:0;left:0;right:0;z-index:2147483646;background:#eef2ff;color:#312e81;padding:6px 10px;font:11px ui-monospace,Menlo,monospace;border-top:2px solid #6366f1;';stamp.id='ss-diag-stamp';stamp.textContent='diag overlay armed @ '+new Date().toISOString()+' on '+location.pathname;var as=function(){if(document.body){document.body.appendChild(stamp)}else{setTimeout(as,30)}};as()}catch(e){}})();`
-          }}
-        />
         {/* Viewport meta tag for mobile responsiveness */}
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
         <meta name="format-detection" content="telephone=no" />

--- a/components/SplitsaveApp.tsx
+++ b/components/SplitsaveApp.tsx
@@ -835,7 +835,7 @@ export function SplitsaveApp() {
   return (
     <ErrorBoundary>
       {isMobile ? (
-        <MobileAppLayout>
+        <MobileAppLayout currentView={currentView} onNavigate={handleNavigation}>
           {mainContent}
         </MobileAppLayout>
       ) : (

--- a/components/mobile/MobileAppLayout.tsx
+++ b/components/mobile/MobileAppLayout.tsx
@@ -7,12 +7,15 @@ import { useAuth } from '@/components/auth/SimpleAuthProvider'
 
 interface MobileAppLayoutProps {
   children: React.ReactNode
+  // Driven by SplitsaveApp so the bottom nav controls the same view state that
+  // renders the page. Without these the tabs only highlighted and did nothing.
+  currentView?: string
+  onNavigate?: (view: string) => void
 }
 
-export function MobileAppLayout({ children }: MobileAppLayoutProps) {
+export function MobileAppLayout({ children, currentView = 'overview', onNavigate }: MobileAppLayoutProps) {
   const { isMobile } = useMobileDetection()
   const { user, signOut } = useAuth()
-  const [currentPage, setCurrentPage] = useState('dashboard')
   const [isPWA, setIsPWA] = useState(false)
 
   // Detect PWA mode
@@ -58,9 +61,9 @@ export function MobileAppLayout({ children }: MobileAppLayoutProps) {
       </main>
 
       {/* Bottom Navigation */}
-      <MobileNavigation 
-        currentPage={currentPage} 
-        onNavigate={setCurrentPage} 
+      <MobileNavigation
+        currentPage={currentView}
+        onNavigate={onNavigate}
       />
     </div>
   )

--- a/components/mobile/MobileNavigation.tsx
+++ b/components/mobile/MobileNavigation.tsx
@@ -9,7 +9,7 @@ interface MobileNavigationProps {
   onNavigate?: (page: string) => void
 }
 
-export function MobileNavigation({ currentPage = 'dashboard', onNavigate }: MobileNavigationProps) {
+export function MobileNavigation({ currentPage = 'overview', onNavigate }: MobileNavigationProps) {
   const { isMobile } = useMobileDetection()
   const [isPWA, setIsPWA] = useState(false)
 
@@ -24,12 +24,13 @@ export function MobileNavigation({ currentPage = 'dashboard', onNavigate }: Mobi
 
   if (!isMobile) return null
 
+  // IDs must match the view names SplitsaveApp uses in currentView/handleNavigation.
   const navigationItems = [
-    { id: 'dashboard', label: 'Dashboard', icon: '🏠' },
-    { id: 'expenses', label: 'Expenses', icon: '💰' },
+    { id: 'overview', label: 'Dashboard', icon: '🏠' },
+    { id: 'expenses', label: 'Money', icon: '💰' },
     { id: 'goals', label: 'Goals', icon: '🎯' },
-    { id: 'notifications', label: 'Alerts', icon: '🔔' },
-    { id: 'profile', label: 'Profile', icon: '👤' },
+    { id: 'partnerships', label: 'Partners', icon: '👥' },
+    { id: 'account', label: 'Account', icon: '⚙️' },
   ]
 
   return (


### PR DESCRIPTION
## Summary

Two small follow-ups bundled together.

### Remove `?diag=1` overlay from production

The on-page error overlay added during diagnosis served its purpose — it captured the unguarded `Notification` reference fixed in #64. Devices that armed the overlay during testing still have `ss-diag=1` in `localStorage`, which kept showing the bottom "diag overlay armed" stamp on the live site (visible artifact on production).

Removes the inline overlay script from `app/layout.tsx`. The leftover `localStorage` flag becomes inert — nothing reads it anymore.

**Kept:** the inline service-worker reset script (separate concern — recovers stuck PWAs); `public/diag.html` (hidden tool at an explicit URL, useful for future investigations).

### Make mobile bottom nav actually switch views

The bottom navigation tabs in the PWA only highlighted the active tab and did nothing else — taps had no effect on what was rendered. Root cause:

- `MobileAppLayout` kept its own local `currentPage` state that nothing read for rendering.
- The real view state lives in `SplitsaveApp.currentView`, which the bottom nav never reached.
- The tab IDs (`dashboard`, `profile`) didn't match `SplitsaveApp`'s view names (`overview`, `account`), so even a wired-up nav would have no-op'd.

Fixes:
- `MobileAppLayout` takes `currentView` / `onNavigate` props and drops its local state.
- `SplitsaveApp` passes its `currentView` and `handleNavigation` through.
- `MobileNavigation` item IDs align with `SplitsaveApp`'s view names; labels match the desktop nav (Money, Partners, Account).

## Test plan

- [x] `npm run build` compiles successfully
- [x] No stale references to the removed local `currentPage` state
- [ ] After deploy: open the PWA, tap each bottom-nav tab, confirm the view switches (Dashboard → Money → Goals → Partners → Account)
- [ ] After deploy: confirm the bottom "diag overlay armed" stamp is gone on the live site

https://claude.ai/code/session_013wV9cy54xibXwwA3hUMrvC